### PR TITLE
include test fail messages for both test methods

### DIFF
--- a/tests/common/test_ecss.py
+++ b/tests/common/test_ecss.py
@@ -10,10 +10,12 @@ class TestStringMethods(unittest.TestCase):
         now = time()
         scet = scet_int_from_time(now)
         now2 = scet_int_to_time(scet)
-        self.assertAlmostEqual(now, now2, 1)
+        message = "test failed: SCET times not equal"
+        self.assertAlmostEqual(now, now2, 1, message)
 
     def test_utc_time(self):
         now = time()
         utc = utc_int_from_time(now)
         now2 = utc_int_to_time(utc)
-        self.assertAlmostEqual(now, now2, 1)
+        message = "test failed: UTC times not equal"
+        self.assertAlmostEqual(now, now2, 1, message)


### PR DESCRIPTION
Do we want a return statement in case of failed tests? I've thrown in a simple message for the failed test param