### PR TITLE
Faster imports

### DIFF
--- a/olaf/__init__.py
+++ b/olaf/__init__.py
@@ -13,7 +13,7 @@ from ._internals.app import App, app
 from ._internals.master_node import MasterNode
 from ._internals.node import NetworkError, Node, NodeStop
 from ._internals.rest_api import RestAPI, render_olaf_template, rest_api
-from ._internals.services.logs import TMP_LOGS_FILE
+from ._internals.services.logs import get_log_file_handler
 from ._internals.updater import Updater, UpdaterState
 from .common.adc import Adc
 from .common.cpufreq import A8_CPUFREQS, get_cpufreq, get_cpufreq_gov, set_cpufreq, set_cpufreq_gov
@@ -123,9 +123,7 @@ def olaf_setup(name: str, args: Optional[Namespace] = None) -> tuple[Namespace, 
         stream_handler.setFormatter(formatter)
         handlers.append(stream_handler)
 
-    if os.path.isfile(TMP_LOGS_FILE):
-        os.remove(TMP_LOGS_FILE)
-    file_handler = logging.FileHandler(TMP_LOGS_FILE)
+    file_handler = get_log_file_handler()
     file_handler.setFormatter(formatter)
     handlers.append(file_handler)
 

--- a/olaf/__init__.py
+++ b/olaf/__init__.py
@@ -15,6 +15,7 @@ from ._internals.node import NetworkError, Node, NodeStop
 from ._internals.rest_api import RestAPI, render_olaf_template, rest_api
 from ._internals.services.logs import get_log_file_handler
 from ._internals.updater import Updater, UpdaterState
+from .common import natsorted
 from .common.adc import Adc
 from .common.cpufreq import A8_CPUFREQS, get_cpufreq, get_cpufreq_gov, set_cpufreq, set_cpufreq_gov
 from .common.daemon import Daemon, DaemonState

--- a/olaf/_internals/app.py
+++ b/olaf/_internals/app.py
@@ -1,5 +1,6 @@
 """OLAF App."""
 
+import logging
 import os
 import signal
 import subprocess
@@ -7,7 +8,6 @@ from typing import Union
 
 import can
 import canopen
-from loguru import logger
 
 from ..common.resource import Resource
 from ..common.service import Service
@@ -23,6 +23,8 @@ from .services.logs import LogsService
 from .services.os_command import OsCommandService
 from .services.updater import UpdaterService
 from .updater import Updater
+
+logger = logging.getLogger(__file__)
 
 
 class App:

--- a/olaf/_internals/master_node.py
+++ b/olaf/_internals/master_node.py
@@ -1,14 +1,16 @@
 """OreSat CANopen Master Node class to support the C3"""
 
+import logging
 from collections import namedtuple
 from time import monotonic
 from typing import Any, Dict, Union
 
 import can
 import canopen
-from loguru import logger
 
 from .node import NetworkError, Node
+
+logger = logging.getLogger(__file__)
 
 NodeHeartbeatInfo = namedtuple("NodeHeartbeatInfo", ["state", "timestamp", "time_since_boot"])
 

--- a/olaf/_internals/node.py
+++ b/olaf/_internals/node.py
@@ -1,5 +1,6 @@
 """OreSat CANopen Node"""
 
+import logging
 import os
 import struct
 import subprocess
@@ -11,11 +12,12 @@ from typing import Any, Callable, Dict, Union
 import can
 import canopen
 import psutil
-from loguru import logger
 
 from ..common.daemon import Daemon
 from ..common.oresat_file_cache import OreSatFileCache
 from ..common.timer_loop import TimerLoop
+
+logger = logging.getLogger(__file__)
 
 
 class CanState(IntEnum):

--- a/olaf/_internals/resources/ecss.py
+++ b/olaf/_internals/resources/ecss.py
@@ -1,12 +1,13 @@
 """Resource for ECSS CANBus Extended Protocal standards"""
 
+import logging
 from os import geteuid
 from time import CLOCK_REALTIME, clock_settime, time
 
-from loguru import logger
-
 from ...common.ecss import scet_int_from_time, scet_int_to_time, utc_int_from_time, utc_int_to_time
 from ...common.resource import Resource
+
+logger = logging.getLogger(__file__)
 
 
 class EcssResource(Resource):

--- a/olaf/_internals/resources/fread.py
+++ b/olaf/_internals/resources/fread.py
@@ -1,13 +1,14 @@
 """Resource for readings oresat files over the CAN bus"""
 
 import json
+import logging
 from os import listdir, remove
 from os.path import basename
 from pathlib import Path
 
-from loguru import logger
-
 from ...common.resource import Resource
+
+logger = logging.getLogger(__file__)
 
 
 class FreadResource(Resource):

--- a/olaf/_internals/resources/fwrite.py
+++ b/olaf/_internals/resources/fwrite.py
@@ -1,14 +1,15 @@
 """Resource for writing oresat files over the CAN bus"""
 
 import json
+import logging
 from os import listdir, remove
 from os.path import basename
 from pathlib import Path
 
-from loguru import logger
-
 from ...common.oresat_file import OreSatFile
 from ...common.resource import Resource
+
+logger = logging.getLogger(__file__)
 
 
 class FwriteResource(Resource):

--- a/olaf/_internals/resources/system.py
+++ b/olaf/_internals/resources/system.py
@@ -1,14 +1,15 @@
 """Resource for the system."""
 
+import logging
 from time import monotonic, time
 
 import psutil
 
-from olaf import logger
-
 from ...common.eeprom import Eeprom
 from ...common.resource import Resource
 from ..node import NodeStop
+
+logger = logging.getLogger(__file__)
 
 
 class SystemResource(Resource):

--- a/olaf/_internals/rest_api/__init__.py
+++ b/olaf/_internals/rest_api/__init__.py
@@ -10,12 +10,13 @@ from typing import Union
 
 import canopen
 from flask import Flask, jsonify, render_template, request, send_from_directory
-from loguru import logger
 from natsort import natsorted
 from oresat_configs import OreSatId
 from werkzeug.serving import make_server
 
 from ..app import app
+
+logger = logging.getLogger(__file__)
 
 DATA_TYPE_NAMES = {
     canopen.objectdictionary.BOOLEAN: "BOOLEAN",

--- a/olaf/_internals/rest_api/__init__.py
+++ b/olaf/_internals/rest_api/__init__.py
@@ -10,10 +10,10 @@ from typing import Union
 
 import canopen
 from flask import Flask, jsonify, render_template, request, send_from_directory
-from natsort import natsorted
 from oresat_configs import OreSatId
 from werkzeug.serving import make_server
 
+from ...common import natsorted
 from ..app import app
 
 logger = logging.getLogger(__file__)

--- a/olaf/_internals/rest_api/templates/base.html
+++ b/olaf/_internals/rest_api/templates/base.html
@@ -4,7 +4,7 @@
   <style>
     #headerGrid {
       display: grid;
-      grid-template-columns: 25% 50% 25%;
+      grid-template-columns: 35% 30% 35%;
     }
     #headerCenter {
       text-align: center;

--- a/olaf/_internals/rest_api/templates/root.html
+++ b/olaf/_internals/rest_api/templates/root.html
@@ -4,7 +4,7 @@
   <style>
     #headerGrid {
       display: grid;
-      grid-template-columns: 25% 50% 25%;
+      grid-template-columns: 35% 30% 35%;
     }
     #headerCenter {
       text-align: center;

--- a/olaf/_internals/services/logs.py
+++ b/olaf/_internals/services/logs.py
@@ -1,4 +1,4 @@
-"""Service for getting system logs"""
+"""Service for the getting system logs over CAN."""
 
 import logging
 import os
@@ -10,6 +10,13 @@ from ...common.service import Service
 logger = logging.getLogger(__file__)
 
 TMP_LOGS_FILE = "/tmp/olaf.log"
+
+
+def get_log_file_handler() -> logging.FileHandler:
+    """Get the boot log file handler and clean up temp log file used by LogsService."""
+    if os.path.isfile(TMP_LOGS_FILE):
+        os.remove(TMP_LOGS_FILE)
+    return logging.FileHandler(TMP_LOGS_FILE)
 
 
 class LogsService(Service):

--- a/olaf/_internals/services/logs.py
+++ b/olaf/_internals/services/logs.py
@@ -1,23 +1,15 @@
 """Service for getting system logs"""
 
+import logging
 import os
 import tarfile
-
-from loguru import logger
 
 from ...common.oresat_file import new_oresat_file
 from ...common.service import Service
 
+logger = logging.getLogger(__file__)
+
 TMP_LOGS_FILE = "/tmp/olaf.log"
-
-
-def logger_tmp_file_setup(level: str):
-    """Congfigure logger to save to tmp file for LogsService"""
-
-    # log file for log service (overrides each time app starts)
-    if os.path.isfile(TMP_LOGS_FILE):
-        os.remove(TMP_LOGS_FILE)
-    logger.add(TMP_LOGS_FILE, level=level, backtrace=True)
 
 
 class LogsService(Service):

--- a/olaf/_internals/services/os_command.py
+++ b/olaf/_internals/services/os_command.py
@@ -1,11 +1,12 @@
 """Service for running OS (bash) commands over CAN bus."""
 
+import logging
 import subprocess
 from enum import IntEnum
 
-from loguru import logger
-
 from ...common.service import Service
+
+logger = logging.getLogger(__file__)
 
 
 class OsCommandState(IntEnum):

--- a/olaf/_internals/services/updater.py
+++ b/olaf/_internals/services/updater.py
@@ -1,10 +1,13 @@
 """Service for interacting with the updater"""
 
+import logging
+
 import canopen
-from loguru import logger
 
 from ...common.service import Service
 from ..updater import Updater, UpdaterError
+
+logger = logging.getLogger(__file__)
 
 
 class UpdaterService(Service):

--- a/olaf/_internals/updater.py
+++ b/olaf/_internals/updater.py
@@ -1,6 +1,7 @@
 """OreSat Linux updater"""
 
 import json
+import logging
 import subprocess
 import tarfile
 from enum import IntEnum
@@ -9,10 +10,10 @@ from os.path import abspath, basename, isfile
 from pathlib import Path
 from shutil import rmtree
 
-from loguru import logger
-
 from ..common.oresat_file import OreSatFile, new_oresat_file
 from ..common.oresat_file_cache import OreSatFileCache
+
+logger = logging.getLogger(__file__)
 
 INSTRUCTIONS_FILE = "instructions.txt"
 """The instructions file that is always in a OreSat Linux update archive. It

--- a/olaf/common/__init__.py
+++ b/olaf/common/__init__.py
@@ -20,6 +20,10 @@ def natsorted(data: list[str], ignore_case: bool = False) -> list[str]:
         List of natural sorted strings.
     """
 
-    convert = lambda text: int(text) if text.isdigit() else (text.lower() if ignore_case else text)
-    alphanum_key = lambda key: [convert(c) for c in re.split("([0-9]+)", key)]
+    def convert(text):
+        return int(text) if text.isdigit() else (text.lower() if ignore_case else text)
+
+    def alphanum_key(key):
+        return [convert(c) for c in re.split("([0-9]+)", key)]
+
     return sorted(data, key=alphanum_key)

--- a/olaf/common/__init__.py
+++ b/olaf/common/__init__.py
@@ -4,9 +4,22 @@ import re
 
 
 def natsorted(data: list[str], ignore_case: bool = False) -> list[str]:
-    """Sort a list with natural sort. Option to ignore case as well."""
+    """
+    Sort a list with natural sort.
 
-    # pylint: disable=unnecessary-lambda-assignment
+    Parameters
+    ----------
+    data: list[str]
+        List of strings to sort.
+    ignore_case: bool
+        Set to True to ignore case
+
+    Returns
+    -------
+    list[str]
+        List of natural sorted strings.
+    """
+
     convert = lambda text: int(text) if text.isdigit() else (text.lower() if ignore_case else text)
     alphanum_key = lambda key: [convert(c) for c in re.split("([0-9]+)", key)]
     return sorted(data, key=alphanum_key)

--- a/olaf/common/__init__.py
+++ b/olaf/common/__init__.py
@@ -1,0 +1,12 @@
+"""Common OLAF class and functions."""
+
+import re
+
+
+def natsorted(data: list[str], ignore_case: bool = False) -> list[str]:
+    """Sort a list with natural sort. Option to ignore case as well."""
+
+    # pylint: disable=unnecessary-lambda-assignment
+    convert = lambda text: int(text) if text.isdigit() else (text.lower() if ignore_case else text)
+    alphanum_key = lambda key: [convert(c) for c in re.split("([0-9]+)", key)]
+    return sorted(data, key=alphanum_key)

--- a/olaf/common/__init__.py
+++ b/olaf/common/__init__.py
@@ -20,10 +20,18 @@ def natsorted(data: list[str], ignore_case: bool = False) -> list[str]:
         List of natural sorted strings.
     """
 
+    if not data:
+        return []
+
     def convert(text):
-        return int(text) if text.isdigit() else (text.lower() if ignore_case else text)
+        r = text
+        if text.isdigit():
+            r = int(text)
+        elif ignore_case:
+            text.lower()
+        return r
 
     def alphanum_key(key):
-        return [convert(c) for c in re.split("([0-9]+)", key)]
+        return [convert(c) for c in re.split("([0-9]+)", str(key))]
 
     return sorted(data, key=alphanum_key)

--- a/olaf/common/cpufreq.py
+++ b/olaf/common/cpufreq.py
@@ -1,8 +1,10 @@
 """Functions to get/set the CPU frequency and its governor on the Octavo A8."""
 
+import logging
 from os import geteuid
 
-from loguru import logger
+logger = logging.getLogger(__file__)
+
 
 A8_CPUFREQS = [300, 600, 720, 800, 1000]
 """list: CPU frequencies for the Cortex A8 in MHz"""

--- a/olaf/common/oresat_file.py
+++ b/olaf/common/oresat_file.py
@@ -7,7 +7,7 @@ from time import time
 
 def new_oresat_file(keyword: str, card: str = "", date: float = -1.0, ext: str = "") -> str:
     """
-    Convience function for making valid oresat file_names
+    Convenience function for making valid oresat file names.
 
     Parameters
     ----------

--- a/olaf/common/oresat_file_cache.py
+++ b/olaf/common/oresat_file_cache.py
@@ -7,8 +7,7 @@ from os.path import abspath, basename, isfile
 from pathlib import Path
 from threading import Lock
 
-from natsort import natsorted
-
+from . import natsorted
 from .oresat_file import OreSatFile
 
 

--- a/olaf/common/oresat_file_cache.py
+++ b/olaf/common/oresat_file_cache.py
@@ -7,7 +7,6 @@ from os.path import abspath, basename, isfile
 from pathlib import Path
 from threading import Lock
 
-from . import natsorted
 from .oresat_file import OreSatFile
 
 
@@ -37,7 +36,7 @@ class OreSatFileCache:
                 self._data.append(oresat_file)
             except Exception:  # pylint: disable=W0718
                 remove(self._dir + f)  # invalid file name
-        self._data = natsorted(self._data)
+        self._data = sorted(self._data)
 
     def __len__(self) -> int:
         with self._lock:
@@ -78,7 +77,7 @@ class OreSatFileCache:
 
             if not overwrite:
                 self._data.append(oresat_file)
-                self._data = natsorted(self._data)
+                self._data = sorted(self._data)
 
     def remove(self, file_name: str):
         """Remove a file from cache

--- a/olaf/common/resource.py
+++ b/olaf/common/resource.py
@@ -1,8 +1,10 @@
 """The OreSat Linux base app resource. It is a nice way to organize OD callbacks."""
 
-from loguru import logger
+import logging
 
 from .._internals.node import Node
+
+logger = logging.getLogger(__file__)
 
 
 class Resource:

--- a/olaf/common/service.py
+++ b/olaf/common/service.py
@@ -1,11 +1,12 @@
 """The OLAF base Service class. A Resource with a dedicated thread."""
 
+import logging
 from enum import IntEnum
 from threading import Event, Thread
 
-from loguru import logger
-
 from .._internals.node import Node
+
+logger = logging.getLogger(__file__)
 
 
 class ServiceState(IntEnum):

--- a/olaf/common/timer_loop.py
+++ b/olaf/common/timer_loop.py
@@ -1,12 +1,13 @@
 """A quick timer-based class that calls a function in a loop"""
 
+import logging
 from threading import Event, Thread
 from time import monotonic
 from typing import Union
 
 import canopen
 
-from .. import logger
+logger = logging.getLogger(__file__)
 
 
 class TimerLoop:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,6 @@ classifiers = [
 dependencies = [
     "canopen",
     "flask",
-    "loguru",
     "natsort",
     "psutil",
     "oresat-configs",
@@ -63,13 +62,16 @@ linters = "pycodestyle,pyflakes,pylint,mccabe,mypy,radon"
 # W0102:    Dangerous default value as argument
 # W0107:    Unnecessary pass statement
 # R0903:    Too few public methods
-ignore = "E402,C901,C0103,E203,R0912,R0915,R901,R901,R0914,C0413,C0206,R1716,W1514,R0902,R0913,W0707,W0102,W0107,R0903"
+# W1201:    Use % formatting in logging functions
+# W1203:    Use %s formatting in logging functions
+ignore = "E402,C901,C0103,E203,R0912,R0915,R901,R901,R0914,C0413,C0206,R1716,W1514,R0902,R0913,W0707,W0102,W0107,R0903,W1201,W1203"
 max_line_length = 100
 
 [[tool.pylama.files]]
 path = "*/__init__.py"
 # W0611:    Imported but unused
-ignore = "W0611"
+# W1201:    Use % formatting in logging functions
+ignore = "W0611,W1201"
 
 [[tool.pylama.files]]
 path = "tests/*"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,8 +71,7 @@ linters = "pycodestyle,pyflakes,pylint,mccabe,mypy,radon"
 # R0903:    Too few public methods
 # W1201:    Use % formatting in logging functions
 # W1203:    Use %s formatting in logging functions
-# E731:     Do not assign a lambda expression, use a def
-ignore = "E402,C901,C0103,E203,R0912,R0915,R901,R901,R0914,C0413,C0206,R1716,W1514,R0902,R0913,W0707,W0102,W0107,R0903,W1201,W1203,E731"
+ignore = "E402,C901,C0103,E203,R0912,R0915,R901,R901,R0914,C0413,C0206,R1716,W1514,R0902,R0913,W0707,W0102,W0107,R0903,W1201,W1203"
 max_line_length = 100
 
 [[tool.pylama.files]]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -83,7 +83,8 @@ ignore = "W0611,W1201"
 [[tool.pylama.files]]
 path = "tests/*"
 # W0212:    Access to a protected member of a class
-ignore = "W0212"
+# C0114:    Missing module docstring
+ignore = "W0212,C0114"
 
 [[tool.pylama.files]]
 path = "*/_version.py"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,6 @@ classifiers = [
 dependencies = [
     "canopen",
     "flask",
-    "natsort",
     "psutil",
     "oresat-configs",
 ]
@@ -64,7 +63,8 @@ linters = "pycodestyle,pyflakes,pylint,mccabe,mypy,radon"
 # R0903:    Too few public methods
 # W1201:    Use % formatting in logging functions
 # W1203:    Use %s formatting in logging functions
-ignore = "E402,C901,C0103,E203,R0912,R0915,R901,R901,R0914,C0413,C0206,R1716,W1514,R0902,R0913,W0707,W0102,W0107,R0903,W1201,W1203"
+# E731:     Do not assign a lambda expression, use a def
+ignore = "E402,C901,C0103,E203,R0912,R0915,R901,R901,R0914,C0413,C0206,R1716,W1514,R0902,R0913,W0707,W0102,W0107,R0903,W1201,W1203,E731"
 max_line_length = 100
 
 [[tool.pylama.files]]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,12 +19,20 @@ classifiers = [
     "Topic :: Software Development :: Libraries :: Application Frameworks",
 ]
 dependencies = [
+    "python-can>=4.3.0",
     "canopen",
     "flask",
     "psutil",
     "oresat-configs",
 ]
 dynamic = ["version"]
+
+[project.optional-dependencies]
+lint = [
+    "black",
+    "isort",
+    "pylama",
+]
 
 [tool.setuptools.packages.find]
 exclude = ["docs*", "tests*"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,6 @@ build
 canopen
 flask
 isort
-loguru
 natsort
 oresat-configs
 psutil

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,6 @@ build
 canopen
 flask
 isort
-natsort
 oresat-configs
 psutil
 pylama[all]

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,7 @@ build
 canopen
 flask
 isort
+python-can>=4.3.0
 oresat-configs
 psutil
 pylama[all]

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,4 @@
+import logging
+
+# this will stop logging to console
+logging.disable(logging.CRITICAL)

--- a/tests/internals/resources/__init__.py
+++ b/tests/internals/resources/__init__.py
@@ -4,10 +4,8 @@ import can
 import canopen
 from oresat_configs import OreSatConfig, OreSatId
 
-from olaf import OreSatFileCache, Resource, logger
+from olaf import OreSatFileCache, Resource
 from olaf._internals.node import Node
-
-logger.disable("olaf")
 
 
 class MockNode(Node):

--- a/tests/internals/resources/test_fread.py
+++ b/tests/internals/resources/test_fread.py
@@ -6,7 +6,7 @@ import string
 import unittest
 from os.path import basename
 
-from olaf import new_oresat_file, natsorted
+from olaf import natsorted, new_oresat_file
 from olaf._internals.resources.fread import FreadResource
 
 from . import MockApp

--- a/tests/internals/resources/test_fread.py
+++ b/tests/internals/resources/test_fread.py
@@ -6,7 +6,7 @@ import string
 import unittest
 from os.path import basename
 
-from olaf import new_oresat_file
+from olaf import new_oresat_file, natsorted
 from olaf._internals.resources.fread import FreadResource
 
 from . import MockApp
@@ -88,7 +88,7 @@ class TestFreadResource(unittest.TestCase):
         self.assertEqual(self.app.sdo_read(index, subindex_file_data).decode(), file_data2)
         self.assertEqual(self.app.sdo_read(index, subindex_len), 2)
         file_names = json.loads(self.app.sdo_read(index, subindex_files_json))
-        self.assertListEqual(file_names, [file_name, file_name2])
+        self.assertListEqual(file_names, natsorted([file_name, file_name2]))
 
         # delete the first file
         self.app.sdo_write(index, subindex_file_name, basename(file_name))

--- a/tests/internals/resources/test_fread.py
+++ b/tests/internals/resources/test_fread.py
@@ -6,7 +6,7 @@ import string
 import unittest
 from os.path import basename
 
-from olaf import natsorted, new_oresat_file
+from olaf import new_oresat_file
 from olaf._internals.resources.fread import FreadResource
 
 from . import MockApp
@@ -88,7 +88,7 @@ class TestFreadResource(unittest.TestCase):
         self.assertEqual(self.app.sdo_read(index, subindex_file_data).decode(), file_data2)
         self.assertEqual(self.app.sdo_read(index, subindex_len), 2)
         file_names = json.loads(self.app.sdo_read(index, subindex_files_json))
-        self.assertListEqual(file_names, natsorted([file_name, file_name2]))
+        self.assertListEqual(file_names, [file_name, file_name2])
 
         # delete the first file
         self.app.sdo_write(index, subindex_file_name, basename(file_name))

--- a/tests/internals/resources/test_fwrite.py
+++ b/tests/internals/resources/test_fwrite.py
@@ -7,7 +7,7 @@ import unittest
 from os import remove
 from os.path import basename
 
-from olaf import natsorted, new_oresat_file
+from olaf import new_oresat_file
 from olaf._internals.resources.fwrite import FwriteResource
 
 from . import MockApp
@@ -77,7 +77,7 @@ class TestFwriteResource(unittest.TestCase):
         self.assertEqual(len(self.app.node.fwrite_cache), 2)
         self.assertEqual(self.app.sdo_read(index, subindex_len), 2)
         file_names = json.loads(self.app.sdo_read(index, subindex_files_json))
-        self.assertListEqual(file_names, natsorted([file_name, file_name2]))
+        self.assertListEqual(file_names, [file_name, file_name2])
 
         # remove test file
         remove(file_path2)

--- a/tests/internals/resources/test_fwrite.py
+++ b/tests/internals/resources/test_fwrite.py
@@ -7,7 +7,7 @@ import unittest
 from os import remove
 from os.path import basename
 
-from olaf import new_oresat_file
+from olaf import new_oresat_file, natsorted
 from olaf._internals.resources.fwrite import FwriteResource
 
 from . import MockApp
@@ -77,7 +77,7 @@ class TestFwriteResource(unittest.TestCase):
         self.assertEqual(len(self.app.node.fwrite_cache), 2)
         self.assertEqual(self.app.sdo_read(index, subindex_len), 2)
         file_names = json.loads(self.app.sdo_read(index, subindex_files_json))
-        self.assertListEqual(file_names, [file_name, file_name2])
+        self.assertListEqual(file_names, natsorted([file_name, file_name2]))
 
         # remove test file
         remove(file_path2)

--- a/tests/internals/resources/test_fwrite.py
+++ b/tests/internals/resources/test_fwrite.py
@@ -7,7 +7,7 @@ import unittest
 from os import remove
 from os.path import basename
 
-from olaf import new_oresat_file, natsorted
+from olaf import natsorted, new_oresat_file
 from olaf._internals.resources.fwrite import FwriteResource
 
 from . import MockApp

--- a/tests/internals/services/__init__.py
+++ b/tests/internals/services/__init__.py
@@ -4,10 +4,8 @@ import can
 import canopen
 from oresat_configs import OreSatConfig, OreSatId
 
-from olaf import OreSatFileCache, Service, logger
+from olaf import OreSatFileCache, Service
 from olaf._internals.node import Node
-
-logger.disable("olaf")
 
 
 class MockNode(Node):


### PR DESCRIPTION
Tested with `python -X importtime run.py gps -b can0` on C3 card at max CPU frequency

Import time before changes: 5.9s
Import time after changes: 4.1s

Changes:
- Replaced `natsort` with a custom function (removed 300ms)
- Replaced `loguru` with build-in `logging` module (removed 260ms)
- Set minimum `python-can` to 4.3.0 (release fixed internal `pkg_resource` slowdown, removed 1s)

Could remove 1.5s more if removed or split out the`Flask` app, but that could make the projects harder to modify for new students.