### PR TITLE
Fix (by ignoring) EEPROM read OSError

### DIFF
--- a/olaf/__init__.py
+++ b/olaf/__init__.py
@@ -133,7 +133,7 @@ def olaf_setup(name: str, args: Optional[Namespace] = None) -> tuple[Namespace, 
         eeprom = Eeprom()
         version = f"{eeprom.major}.{eeprom.minor}"
         logger.info(f"detected v{version} card")
-    except (PermissionError, FileNotFoundError):
+    except (PermissionError, FileNotFoundError, OSError):
         logger.warning("could not read hardware info from eeprom")
     if args.hardware_version != "0.0":
         version = args.hardware_version


### PR DESCRIPTION
A new kernel update means trying to read the eeprom on my dev machine now throws an OSError. It should be ignored like the others.