### PR TITLE
Handle more eeprom errors

### DIFF
--- a/olaf/__init__.py
+++ b/olaf/__init__.py
@@ -129,12 +129,13 @@ def olaf_setup(name: str, args: Optional[Namespace] = None) -> tuple[Namespace, 
         od["flight_mode"].value = False
 
     version = "0.0"
-    try:
-        eeprom = Eeprom()
-        version = f"{eeprom.major}.{eeprom.minor}"
-        logger.info(f"detected v{version} card")
-    except (PermissionError, FileNotFoundError, OSError):
-        logger.warning("could not read hardware info from eeprom")
+    if not args.mock_hw:
+        try:
+            eeprom = Eeprom()
+            version = f"{eeprom.major}.{eeprom.minor}"
+            logger.info(f"detected v{version} card")
+        except (PermissionError, FileNotFoundError, OSError, UnicodeDecodeError):
+            logger.warning("could not read hardware info from eeprom")
     if args.hardware_version != "0.0":
         version = args.hardware_version
     od["versions"]["hw_version"].value = version


### PR DESCRIPTION
While trying to run OLAF on more people's laptops we ran into another type of eeprom read error, where it could read the eeprom but the contents were not a string. This handles that specific case but really we shouldn't be trying to read arbitrary eeproms if hardware is being mocked.

I could add a specific eeprom value to look for but that's not yet common across other projects so this turns it off if any hardware is mocked.