### PR TITLE
Apply linting

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -33,11 +33,11 @@ jobs:
 
     - name: Lint with Ruff
       if: always() && steps.dependencies.conclusion == 'success'
-      run: ruff check tests
+      run: ruff check olaf tests
 
     - name: Check format with Ruff
       if: always() && steps.dependencies.conclusion == 'success'
-      run: ruff format --check --diff tests
+      run: ruff format --check --diff
 
     - name: Type check with mypy
       if: always() && steps.dependencies.conclusion == 'success'
@@ -46,7 +46,7 @@ jobs:
       # run at all than not.
       run: mypy tests --disable-error-code=import-untyped --follow-imports=skip
 
-    - name: Run unittests
+    - name: Run unit tests
       if: always() && steps.dependencies.conclusion == 'success'
       run: pytest
 

--- a/olaf/__init__.py
+++ b/olaf/__init__.py
@@ -1,9 +1,10 @@
 """OLAF (OreSat Linux App Framework)"""
 
+from __future__ import annotations
+
 import sys
 from argparse import ArgumentParser, Namespace
 from logging.handlers import SysLogHandler
-from typing import Optional
 
 from loguru import logger
 from oresat_configs import Mission, OreSatConfig
@@ -28,9 +29,52 @@ from .common.resource import Resource
 from .common.service import Service, ServiceState
 
 try:
-    from ._version import version as __version__  # type: ignore
+    from ._version import version as __version__
 except ImportError:
     __version__ = "0.0.0"  # package is not installed
+
+__all__ = [
+    "A8_CPUFREQS",
+    "GPIO_HIGH",
+    "GPIO_IN",
+    "GPIO_LOW",
+    "GPIO_OUT",
+    "Adc",
+    "App",
+    "CanNetwork",
+    "CanNetworkError",
+    "CanNetworkState",
+    "Daemon",
+    "DaemonState",
+    "Eeprom",
+    "Gpio",
+    "GpioError",
+    "MasterNode",
+    "NetworkError",
+    "Node",
+    "NodeStop",
+    "OreSatFile",
+    "OreSatFileCache",
+    "Pru",
+    "PruError",
+    "PruState",
+    "Resource",
+    "RestAPI",
+    "Service",
+    "ServiceState",
+    "Updater",
+    "UpdaterState",
+    "get_cpufreq",
+    "get_cpufreq_gov",
+    "new_oresat_file",
+    "render_olaf_template",
+    "scet_int_from_time",
+    "scet_int_to_time",
+    "set_cpufreq",
+    "set_cpufreq_gov",
+    "utc_int_from_time",
+    "utc_int_to_time",
+]
 
 olaf_parser = ArgumentParser(prog="OLAF", add_help=False)
 olaf_parser.add_argument("-b", "--bus", default="vcan0", help="CAN bus to use, defaults to vcan0")
@@ -80,7 +124,7 @@ olaf_parser.add_argument(
 )
 
 
-def olaf_setup(name: str, args: Optional[Namespace] = None) -> tuple[Namespace, dict]:
+def olaf_setup(name: str, args: Namespace | None = None) -> tuple[Namespace, OreSatConfig]:
     """
     Parse runtime args and setup the app and REST API.
 
@@ -153,7 +197,7 @@ def olaf_setup(name: str, args: Optional[Namespace] = None) -> tuple[Namespace, 
     return args, config
 
 
-def olaf_run():
+def olaf_run() -> None:
     """Start the app and REST API."""
 
     rest_api.start()

--- a/olaf/__init__.py
+++ b/olaf/__init__.py
@@ -147,10 +147,7 @@ def olaf_setup(name: str, args: Namespace | None = None) -> tuple[Namespace, Ore
         parser = ArgumentParser(parents=[olaf_parser])
         args = parser.parse_args()
 
-    if args.verbose:
-        level = "DEBUG"
-    else:
-        level = "INFO"
+    level = "DEBUG" if args.verbose else "INFO"
 
     logger.remove()  # remove default logger
     if args.log:

--- a/olaf/_internals/app.py
+++ b/olaf/_internals/app.py
@@ -1,18 +1,16 @@
 """OLAF App."""
 
+from __future__ import annotations
+
 import os
 import signal
 import subprocess
-from typing import Union
+from typing import TYPE_CHECKING
 
-import canopen
 from loguru import logger
 
 from ..canopen.master_node import MasterNode
-from ..canopen.network import CanNetwork
 from ..canopen.node import Node, NodeStop
-from ..common.resource import Resource
-from ..common.service import Service
 from .resources.ecss import EcssResource
 from .resources.fread import FreadResource
 from .resources.fwrite import FwriteResource
@@ -22,6 +20,16 @@ from .services.os_command import OsCommandService
 from .services.updater import UpdaterService
 from .updater import Updater
 
+if TYPE_CHECKING:
+    from collections.abc import Callable
+    from types import FrameType
+
+    import canopen
+
+    from ..canopen.network import CanNetwork
+    from ..common.resource import Resource
+    from ..common.service import Service
+
 
 class App:
     """
@@ -30,18 +38,18 @@ class App:
     Use the global ``olaf.app`` obect.
     """
 
-    def __init__(self):
-        self._od = None
-        self._resources = []
-        self._services = []
-        self._node = None
-        self._updater = None
-        self._factory_reset_cb = None
+    def __init__(self) -> None:
+        self._od: canopen.ObjectDictionary | None = None
+        self._resources: list[Resource] = []
+        self._services: list[Service] = []
+        self._node: Node | None = None
+        self._updater: Updater | None = None
+        self._factory_reset_cb: Callable[[], None] | None = None
 
-    def __del__(self):
+    def __del__(self) -> None:
         self.stop()
 
-    def _quit(self, signo, _frame):
+    def _quit(self, signo: int, _frame: FrameType | None) -> None:
         """Called when signals are caught"""
 
         logger.debug(f"signal {signal.Signals(signo).name} was caught")
@@ -51,9 +59,9 @@ class App:
         self,
         network: CanNetwork,
         od: canopen.ObjectDictionary,
-        master_od_db: Union[dict, None] = None,
+        master_od_db: dict[str, canopen.ObjectDictionary] | None = None,
         load_core: bool = True,
-    ):
+    ) -> None:
         """
         Setup the app. Will be called by ``olaf_setup`` automatically.
 
@@ -99,7 +107,7 @@ class App:
             self.add_resource(FwriteResource())
             # self.add_resource(DaemonsResource())
 
-    def add_resource(self, resource: Resource):
+    def add_resource(self, resource: Resource) -> None:
         """
         Add a resource for the app
 
@@ -111,7 +119,7 @@ class App:
 
         self._resources.append(resource)
 
-    def add_service(self, service: Service):
+    def add_service(self, service: Service) -> None:
         """
         Add a resource for the app
 
@@ -123,8 +131,10 @@ class App:
 
         self._services.append(service)
 
-    def run(self):
+    def run(self) -> None:
         """Run the app."""
+        if self._node is None or self._updater is None:
+            raise RuntimeError("setup() must be called first")
 
         # setup event
         for sig in ["SIGTERM", "SIGHUP", "SIGINT"]:
@@ -190,25 +200,25 @@ class App:
             else:
                 logger.error("not running as root, cannot power off the system")
 
-    def stop(self):
+    def stop(self) -> None:
         """End the run loop"""
 
         if self._node:
             self._node.stop()
 
     @property
-    def node(self) -> Node:
+    def node(self) -> Node | None:
         """Node: The CANopen node."""
 
         return self._node
 
-    def set_factory_reset_callback(self, cb_func):
+    def set_factory_reset_callback(self, cb_func: Callable[[], None]) -> None:
         """Set a custom factory reset callback function."""
 
         self._factory_reset_cb = cb_func
 
     @property
-    def od(self) -> canopen.ObjectDictionary:
+    def od(self) -> canopen.ObjectDictionary | None:
         """canopen.ObjectDictionary: The node's Object Dictionary."""
 
         return self._od

--- a/olaf/_internals/resources/daemons.py
+++ b/olaf/_internals/resources/daemons.py
@@ -1,5 +1,7 @@
 """Resource for getting daemons info"""
 
+from __future__ import annotations
+
 from ...common.daemon import DaemonState
 from ...common.resource import Resource
 
@@ -7,48 +9,42 @@ from ...common.resource import Resource
 class DaemonsResource(Resource):
     """Resource for getting daemons info"""
 
-    def __init__(self):
+    def __init__(self) -> None:
         super().__init__()
+        self.index = 'daemons'
 
-        self.index = 0x3005
-        self._total_daemons_obj = None
-        self._select_daemon_obj = None
-        self._daemon_name_obj = None
-        self._daemon_state_obj = None
+    def on_start(self) -> None:
+        self.node.add_sdo_callbacks(self.index, None, self._on_read, None)
 
-    def on_start(self):
-        daemon_manager_obj = self.node.od[self.index]
-        self._total_daemons_obj = daemon_manager_obj[1]
-        self._select_daemon_obj = daemon_manager_obj[4]
-        self._daemon_name_obj = daemon_manager_obj[5]
-        self._daemon_state_obj = daemon_manager_obj[6]
-
-        self._total_daemons_obj.value = len(self.node.daemons)
-
-        self.node.add_sdo_read_callback(self.index, self._on_read)
-
-    def _on_read(self, index: int, subindex: int):
-        ret = None
-
+    def _on_read(self, index: int, subindex: int) -> int | None:
         if index != self.index:
-            return ret
+            return None
+
+        daemon_manager = self.node.od[self.index]
+        total_daemons = daemon_manager['total']
+        total_daemons.value = len(self.node.daemons)
+        select_daemon = daemon_manager[4]
+        # daemon_name = daemon_manager[5]
+        # daemon_state = daemon_manager[6]
 
         if subindex == 2:
             ret = 0
             for i in self.node.daemons.values():
                 if i.status == DaemonState.ACTIVE:
                     ret += 1
-        elif subindex == 3:
+            return ret
+        if subindex == 3:
             ret = 0
             for i in self.node.daemons.values():
                 if i.status == DaemonState.ACTIVE:
                     ret += 1
-        elif subindex == 5:
-            if self._select_daemon_obj.value < self._total_daemons_obj.value:
-                ret = list(self.node.daemons.keys())[self._select_daemon_obj.value]
-        elif subindex == 6:
-            if self._select_daemon_obj.value < self._total_daemons_obj.value:
-                daemon = list(self.node.daemons.values())[self._select_daemon_obj.value]
-                ret = daemon.status.value
+            return ret
+        if subindex == 5:
+            if select_daemon.value < total_daemons.value:
+                return list(self.node.daemons.keys())[select_daemon.value]
+        elif subindex == 6:  # noqa: SIM102
+            if select_daemon.value < total_daemons.value:
+                daemon = list(self.node.daemons.values())[select_daemon.value]
+                return daemon.status.value
 
-        return ret
+        return None

--- a/olaf/_internals/resources/ecss.py
+++ b/olaf/_internals/resources/ecss.py
@@ -12,7 +12,7 @@ from ...common.resource import Resource
 class EcssResource(Resource):
     """Resource for ECSS CANBus Extended Protocal standards"""
 
-    def on_start(self):
+    def on_start(self) -> None:
         self.node.add_sdo_callbacks("scet", None, self.on_scet_read, self.on_scet_write)
         self.node.add_sdo_callbacks("utc", None, self.on_utc_read, self.on_utc_write)
 
@@ -21,7 +21,7 @@ class EcssResource(Resource):
 
         return scet_int_from_time(time())
 
-    def on_scet_write(self, value: int):
+    def on_scet_write(self, value: int) -> None:
         """SDO write callback to set the system time from SCET time stamp."""
 
         ts = scet_int_to_time(value)
@@ -32,13 +32,13 @@ class EcssResource(Resource):
 
         return utc_int_from_time(time())
 
-    def on_utc_write(self, value: int):
+    def on_utc_write(self, value: int) -> None:
         """SDO write callback to set the system time from UTC time stamp."""
 
         ts = utc_int_to_time(value)
         self._set_time(ts)
 
-    def _set_time(self, ts: float):
+    def _set_time(self, ts: float) -> None:
         """set the system time"""
 
         if geteuid() == 0:
@@ -46,5 +46,5 @@ class EcssResource(Resource):
             logger.info(f"{self.__class__.__name__} resource has set system time")
         else:
             logger.error(
-                f"{self.__class__.__name__} resource cannot set system time, not running " "as root"
+                f"{self.__class__.__name__} resource cannot set system time, not running as root"
             )

--- a/olaf/_internals/resources/fread.py
+++ b/olaf/_internals/resources/fread.py
@@ -13,7 +13,7 @@ from ...common.resource import Resource
 class FreadResource(Resource):
     """Resource for readings oresat files over the CAN bus"""
 
-    def __init__(self):
+    def __init__(self) -> None:
         super().__init__()
 
         self.file_path = ""
@@ -23,7 +23,7 @@ class FreadResource(Resource):
         for i in listdir(self.tmp_dir):
             remove(f"{self.tmp_dir}/{i}")
 
-    def on_start(self):
+    def on_start(self) -> None:
         self.node.add_sdo_callbacks("fread_cache", "length", self.on_read_cache_len, None)
         self.node.add_sdo_callbacks("fread_cache", "files_json", self.on_read_cache_json, None)
         self.node.add_sdo_callbacks(
@@ -47,7 +47,7 @@ class FreadResource(Resource):
 
         return basename(self.file_path)
 
-    def on_write_file_name(self, file_name: str):
+    def on_write_file_name(self, file_name: str) -> None:
         """SDO write callback to select the file to read."""
 
         try:
@@ -71,7 +71,7 @@ class FreadResource(Resource):
             logger.error(f"file {self.file_path} does not exist")
         return ret
 
-    def on_write_delete(self, value: bool):
+    def on_write_delete(self, value: bool) -> None:
         """SDO read callback to delete the selected file."""
 
         if not value:

--- a/olaf/_internals/resources/fwrite.py
+++ b/olaf/_internals/resources/fwrite.py
@@ -14,7 +14,7 @@ from ...common.resource import Resource
 class FwriteResource(Resource):
     """Resource for writing oresat files over the CAN bus"""
 
-    def __init__(self):
+    def __init__(self) -> None:
         super().__init__()
 
         self.file_path = ""
@@ -25,7 +25,7 @@ class FwriteResource(Resource):
         for i in listdir(self.tmp_dir):
             remove(f"{self.tmp_dir}/{i}")
 
-    def on_start(self):
+    def on_start(self) -> None:
         self.node.add_sdo_callbacks("fwrite_cache", "length", self.on_read_cache_len, None)
         self.node.add_sdo_callbacks("fwrite_cache", "files_json", self.on_read_cache_json, None)
         self.node.add_sdo_callbacks(
@@ -49,7 +49,7 @@ class FwriteResource(Resource):
 
         return basename(self.file_path)
 
-    def on_write_file_name(self, file_name: str):
+    def on_write_file_name(self, file_name: str) -> None:
         """SDO write callback to select the file to write."""
 
         try:
@@ -59,7 +59,7 @@ class FwriteResource(Resource):
             logger.error(f"{file_name} is not a valid file name format")
             self.file_path = ""
 
-    def on_write_file_data(self, data: bytes):
+    def on_write_file_data(self, data: bytes) -> None:
         """SDO write callback to write the selected file's data."""
 
         if not self.file_path:
@@ -77,7 +77,7 @@ class FwriteResource(Resource):
         # clear file data OD obj value to not waste memory
         self.node.od_write("fwrite_cache", "file_data", b"")
 
-    def on_write_delete(self, value: bool):
+    def on_write_delete(self, value: bool) -> None:
         """SDO read callback to delete the selected file."""
 
         if not value:

--- a/olaf/_internals/resources/system.py
+++ b/olaf/_internals/resources/system.py
@@ -11,7 +11,7 @@ from ...common.resource import Resource
 class SystemResource(Resource):
     """Resource for the system."""
 
-    def on_start(self):
+    def on_start(self) -> None:
         self.node.od_write("system", "reset", 0)
 
         self.node.add_sdo_callbacks("system", "ram_percent", self.on_read_ram, None)
@@ -20,27 +20,27 @@ class SystemResource(Resource):
         self.node.add_sdo_callbacks("system", "unix_time", self.on_read_unix_time, None)
         self.node.add_sdo_callbacks("system", "reset", None, self.on_write_reset)
 
-    def on_read_ram(self):
+    def on_read_ram(self) -> int:
         """SDO read callback for getting the RAM usage percent."""
 
         return int(psutil.virtual_memory().percent)
 
-    def on_read_storage(self):
+    def on_read_storage(self) -> int:
         """SDO read callback for getting the storage usage percent."""
 
         return int(psutil.disk_usage("/").percent)
 
-    def on_read_uptime(self):
+    def on_read_uptime(self) -> int:
         """SDO read callback for getting the uptime."""
 
         return int(monotonic())
 
-    def on_read_unix_time(self):
+    def on_read_unix_time(self) -> int:
         """SDO read callback for getting the current unix time."""
 
         return int(time())
 
-    def on_write_reset(self, value: int):
+    def on_write_reset(self, value: int) -> None:
         """SDO write callback for resetting the system."""
 
         if value in list(NodeStop):

--- a/olaf/_internals/rest_api/__init__.py
+++ b/olaf/_internals/rest_api/__init__.py
@@ -250,8 +250,8 @@ def od_index(index: str) -> Response:
             value = _json_value_to_value(obj.data_type, json_value)
             raw = obj.encode_raw(value)
 
-            app.node._on_sdo_write(idx, None, obj, raw)
-        except Exception as e:  # pylint: disable=W0718
+            app.node._on_sdo_write(idx, None, obj, raw)  # noqa: SLF001
+        except Exception as e:
             logger.error(f"REST API error: {e}")
             return make_error_json(str(e))
 
@@ -294,12 +294,8 @@ def od_subindex(index: str, subindex: str) -> Response:
 
             # convert value from JSON to bytes for SDO callback
             value = _json_value_to_value(obj.data_type, json_value)
-            if obj.data_type in BYTES_TYPES:
-                raw = value
-            else:
-                raw = obj.encode_raw(value)
-
-            app.node._on_sdo_write(idx, subidx, obj, raw)
+            raw = value if obj.data_type in BYTES_TYPES else obj.encode_raw(value)
+            app.node._on_sdo_write(idx, subidx, obj, raw)  # noqa: SLF001
         except Exception as e:  # pylint: disable=W0718
             logger.exception(f"REST API error: {e}")
             return make_error_json(str(e))
@@ -333,20 +329,20 @@ def _object_to_dict(
     if subindex is None:
         try:
             obj = app.node.od[index]
-        except KeyError:
+        except KeyError as e:
             msg = f"0x{index:04X} is not a valid index"
             logger.debug("REST API error: " + msg)
-            raise KeyError(msg)
+            raise KeyError(msg) from e
     else:
         try:
             obj = app.node.od[index][subindex]
-        except KeyError:
+        except KeyError as e:
             msg = f"0x{subindex:02X} not a valid subindex for index 0x{index:04X}"
             logger.debug("REST API error: " + msg)
-            raise KeyError(msg)
+            raise KeyError(msg) from e
 
     if isinstance(obj, canopen.objectdictionary.Variable):
-        value = app.node._on_sdo_read(index, subindex, obj)  # pylint: disable=W0212
+        value = app.node._on_sdo_read(index, subindex, obj)  # noqa: SLF001
         if obj.data_type in BYTES_TYPES and value is not None:
             # encode bytes data types for JSON
             try:
@@ -394,7 +390,7 @@ def get_all_object() -> dict[int, [dict[str, Any]]]:
     for index in app.od:
         if index < 0x3000:
             continue
-        data[index] = _object_to_dict(index, None, False)
+        data[index] = _object_to_dict(index, None, add_values=False)
     return data
 
 

--- a/olaf/_internals/rest_api/__init__.py
+++ b/olaf/_internals/rest_api/__init__.py
@@ -1,21 +1,27 @@
 """OLAF REST API for testing and integration."""
 
+from __future__ import annotations
+
 import base64
 import logging
 import os
 import shutil
 from pathlib import Path
 from threading import Thread
-from typing import Union
+from typing import TYPE_CHECKING, Any
 
 import canopen
-from flask import Flask, jsonify, render_template, request, send_from_directory
+from flask import Flask, Response, jsonify, render_template, request, send_from_directory
 from loguru import logger
 from oresat_configs import Mission
-from werkzeug.serving import make_server
+from werkzeug.serving import BaseWSGIServer, make_server
 
 from ...common import natsorted
 from ..app import app
+
+if TYPE_CHECKING:
+    from flask.app import AppContext
+
 
 DATA_TYPE_NAMES = {
     canopen.objectdictionary.BOOLEAN: "BOOLEAN",
@@ -50,46 +56,47 @@ class RestAPI:
     _PATH = os.path.dirname(os.path.abspath(__file__))
     _TEMPLATE_DIR = "/tmp/oresat/templates"
 
-    def __init__(self):
+    def __init__(self) -> None:
         self.app = Flask(
             "OLAF", template_folder=self._TEMPLATE_DIR, static_folder=f"{self._PATH}/static"
         )
         logging.getLogger("werkzeug").setLevel(logging.ERROR)
-        self._thread = Thread(target=self._run)
-        self._server = None
-        self._ctx = None
+        self._thread: Thread | None = None
+        self._server: BaseWSGIServer | None = None
+        self._ctx: AppContext | None = None
         Path(self._TEMPLATE_DIR).mkdir(parents=True, exist_ok=True)
 
         # add all core templates
         for i in os.listdir(f"{self._PATH}/templates"):
             self.add_template(f"{self._PATH}/templates/{i}")
 
-    def setup(self, address: str, port: int):
+    def setup(self, address: str, port: int) -> None:
         """Setup the REST API thread"""
-
         self._server = make_server(address, port, self.app)
+        self._thread = Thread(target=self._server.serve_forever)
 
-    def start(self):
+    def start(self) -> None:
         """Start the REST API thread"""
 
         logger.info("starting rest api")
         self._ctx = self.app.app_context()
         self._ctx.push()
+        if self._thread is None:
+            raise RuntimeError("Call RestAPI.setup() first")
         self._thread.start()
 
-    def _run(self):
-        self._server.serve_forever()
-
-    def stop(self):
+    def stop(self) -> None:
         """Stop the REST API thread"""
 
         logger.info("stopping rest api")
         if self._server is not None:
             self._server.shutdown()
-        if self._thread.is_alive():
+            self._server = None
+        if self._thread is not None:
             self._thread.join()
+            self._thread = None
 
-    def add_template(self, template_path: str):
+    def add_template(self, template_path: str) -> None:
         """
         Add a Flask template to common templates dir. All templates must be in the same directory.
 
@@ -102,7 +109,7 @@ class RestAPI:
         shutil.copy(template_path, self._TEMPLATE_DIR)
 
 
-def render_olaf_template(template: str, name: str):
+def render_olaf_template(template: str, name: str) -> str:
     """
     Render a standard OLAF template.
 
@@ -119,7 +126,7 @@ def render_olaf_template(template: str, name: str):
     return render_template(template, title=title, name=name)
 
 
-def make_error_json(error: Union[str, Exception]) -> str:
+def make_error_json(error: str | Exception) -> Response:
     """
     Make the stand error json message for the REST API
 
@@ -142,7 +149,7 @@ rest_api = RestAPI()
 
 
 @rest_api.app.route("/")
-def root():
+def root() -> str:
     """Render the root template."""
 
     routes = []
@@ -162,76 +169,75 @@ def root():
 
 
 @rest_api.app.route("/favicon.ico")
-def favicon():
+def favicon() -> Response:
     """Pass the favicon.icon."""
 
     path = os.path.dirname(os.path.abspath(__file__))
     return send_from_directory(f"{path}/static", "favicon.ico")
 
 
-def _json_value_to_value(data_type: int, json_value):
+def _json_value_to_value(data_type: int | None, json_value: str) -> str | bool | float | bytes:
     """Convert JSON value to real OD value to bytes for SDO callback"""
 
-    value = json_value
-
     if data_type == canopen.objectdictionary.BOOLEAN and not isinstance(json_value, bool):
-        value = json_value.lower() == "true"
-    elif data_type in canopen.objectdictionary.INTEGER_TYPES and not isinstance(json_value, int):
-        value = int(json_value, 16) if json_value.startswith("0x") else int(json_value)
-    elif data_type in canopen.objectdictionary.FLOAT_TYPES:
-        value = float(json_value)
-    elif data_type in BYTES_TYPES:
+        return json_value.lower() == "true"
+    if data_type in canopen.objectdictionary.INTEGER_TYPES and not isinstance(json_value, int):
+        return int(json_value, 16) if json_value.startswith("0x") else int(json_value)
+    if data_type in canopen.objectdictionary.FLOAT_TYPES:
+        return float(json_value)
+    if data_type in BYTES_TYPES:
         try:
-            value = base64.decodebytes(json_value.encode("utf-8"))
+            return base64.decodebytes(json_value.encode("utf-8"))
         except AttributeError:
             pass
-
-    return value
+    return json_value
 
 
 @rest_api.app.route("/bus", methods=["GET"])
-def can_bus():
+def can_bus() -> Response:
     """Get CAN bus info."""
 
     return jsonify(
         {
             "channel": app.node.bus,
-            "bitrate": app.od.bitrate // 1000,  # bps -> kpbs
+            "bitrate": app.od.bitrate // 1000 if app.od.bitrate else 0,  # bps -> kpbs
             "status": app.node.bus_state,
         }
     )
 
 
 @rest_api.app.route("/od/<index>/", methods=["GET", "PUT"])
-def od_index_old(index: str):
+def od_index_old(index: str) -> Response:
     """Read or write a value from OD with only a index. For backward compactability."""
 
     return od_index(index)
 
 
 @rest_api.app.route("/od/<index>/<subindex>/", methods=["GET", "PUT"])
-def od_subindex_old(index: str, subindex: str):
+def od_subindex_old(index: str, subindex: str) -> Response:
     """Read or write a value from OD. For backward compactability."""
 
     return od_subindex(index, subindex)
 
 
 @rest_api.app.route("/od/<index>", methods=["GET", "PUT"])
-def od_index(index: str):
+def od_index(index: str) -> Response:
     """Read or write a value from OD with only a index."""
 
     try:
         if index.startswith("0x"):
-            index = int(index, 16)  # type: ignore
+            idx: int | str = int(index, 16)
         elif index[0] in "0123456789":
-            index = int(index)  # type: ignore
+            idx = int(index)
+        else:
+            idx = index
     except ValueError:
         return make_error_json(f"invalid index {index}")
 
     try:
-        obj = app.od[index]
+        obj = app.od[idx]
     except KeyError:
-        index_name = f"0x{index:X}" if isinstance(index, int) else index
+        index_name = f"0x{idx:X}" if isinstance(idx, int) else idx
         msg = f"no object at index {index_name}"
         logger.error(f"REST API error: {msg}")
         return make_error_json(msg)
@@ -244,36 +250,40 @@ def od_index(index: str):
             value = _json_value_to_value(obj.data_type, json_value)
             raw = obj.encode_raw(value)
 
-            app.node._on_sdo_write(index, None, obj, raw)  # pylint: disable=W0212
+            app.node._on_sdo_write(idx, None, obj, raw)
         except Exception as e:  # pylint: disable=W0718
             logger.error(f"REST API error: {e}")
             return make_error_json(str(e))
 
-    return jsonify(_object_to_dict(index))
+    return jsonify(_object_to_dict(idx))
 
 
 @rest_api.app.route("/od/<index>/<subindex>", methods=["GET", "PUT"])
-def od_subindex(index: str, subindex: str):
+def od_subindex(index: str, subindex: str) -> Response:
     """Read or write a value from OD."""
 
     try:
         if index.startswith("0x"):
-            index = int(index, 16)  # type: ignore
+            idx: int | str = int(index, 16)
         elif index[0] in "0123456789":
-            index = int(index)  # type: ignore
+            idx = int(index)
+        else:
+            idx = index
 
         if subindex.startswith("0x"):
-            subindex = int(subindex, 16)  # type: ignore
+            subidx: int | str = int(subindex, 16)
         elif subindex[0] in "0123456789":
-            subindex = int(subindex)  # type: ignore
+            subidx = int(subindex)
+        else:
+            subidx = subindex
     except ValueError:
         return make_error_json(f"invalid index {index} or subindex {subindex}")
 
     try:
-        obj = app.od[index][subindex]
+        obj = app.od[idx][subidx]
     except (KeyError, TypeError):
-        index_name = f"0x{index:X}" if isinstance(index, int) else index
-        subindex_name = f"0x{subindex:X}" if isinstance(subindex, int) else subindex
+        index_name = f"0x{idx:X}" if isinstance(idx, int) else idx
+        subindex_name = f"0x{subidx:X}" if isinstance(subidx, int) else subidx
         msg = f"no object at index {index_name} subindex {subindex_name}"
         logger.error(f"REST API error: {msg}")
         return make_error_json(msg)
@@ -289,19 +299,19 @@ def od_subindex(index: str, subindex: str):
             else:
                 raw = obj.encode_raw(value)
 
-            app.node._on_sdo_write(index, subindex, obj, raw)  # pylint: disable=W0212
+            app.node._on_sdo_write(idx, subidx, obj, raw)
         except Exception as e:  # pylint: disable=W0718
             logger.exception(f"REST API error: {e}")
             return make_error_json(str(e))
 
-    return jsonify(_object_to_dict(index, subindex))
+    return jsonify(_object_to_dict(idx, subidx))
 
 
 def _object_to_dict(
-    index: Union[str, int],
-    subindex: Union[str, int, None] = None,
+    index: str | int,
+    subindex: str | int | None = None,
     add_values: bool = True,
-) -> dict:
+) -> dict[str, Any]:
     """
     Convert a OD object to a dictionary.
 
@@ -378,7 +388,7 @@ def _object_to_dict(
 
 
 @rest_api.app.route("/od-all", methods=["GET"])
-def get_all_object():
+def get_all_object() -> dict[int, [dict[str, Any]]]:
     """Get all object data as a one giant JSON."""
     data = {}
     for index in app.od:
@@ -389,42 +399,42 @@ def get_all_object():
 
 
 @rest_api.app.route("/od")
-def od_template():
+def od_template() -> str:
     """Render the OD template."""
     return render_olaf_template("od.html", name="Object Dictionary")
 
 
 @rest_api.app.route("/os-command")
-def os_command_template():
+def os_command_template() -> str:
     """Render the OS command template."""
     return render_olaf_template("os_command.html", name="OS Command")
 
 
 @rest_api.app.route("/updater")
-def updater_template():
+def updater_template() -> str:
     """Render the updater template."""
     return render_olaf_template("updater.html", name="Updater")
 
 
 @rest_api.app.route("/fwrite")
-def fwrite_template():
+def fwrite_template() -> str:
     """Render the fwrite cache template."""
     return render_olaf_template("fwrite.html", name="Fwrite Cache")
 
 
 @rest_api.app.route("/fread")
-def fread_template():
+def fread_template() -> str:
     """Render the fread cache template."""
     return render_olaf_template("fread.html", name="Fread Cache")
 
 
 @rest_api.app.route("/logs")
-def logs_template():
+def logs_template() -> str:
     """Render the logs template."""
     return render_olaf_template("logs.html", name="Logs")
 
 
 @rest_api.app.route("/reset")
-def reset_template():
+def reset_template() -> str:
     """Render the reset template."""
     return render_olaf_template("reset.html", name="Reset")

--- a/olaf/_internals/services/logs.py
+++ b/olaf/_internals/services/logs.py
@@ -27,7 +27,7 @@ class LogsService(Service):
         self.logs_dir_path = "/var/log/journal/"
 
     def on_start(self) -> None:
-        self.node.od_write("logs", "make_file", False)  # make sure this is False by default
+        self.node.od_write("logs", "make_file", value=False)  # make sure this is False by default
 
         self.node.add_sdo_callbacks("logs", "since_boot", self.on_read_since_boot, None)
 
@@ -42,7 +42,7 @@ class LogsService(Service):
                     t.add(self.logs_dir_path + "/" + i, arcname=i)
 
             self.node.fread_cache.add(tar_file_path, consume=True)
-            self.node.od_write("logs", "make_file", False)
+            self.node.od_write("logs", "make_file", value=False)
 
         self.sleep(0.1)
 
@@ -52,7 +52,5 @@ class LogsService(Service):
         if not os.path.isfile(TMP_LOGS_FILE):
             return "no logs"
 
-        with open(TMP_LOGS_FILE, "r") as f:
-            ret = "".join(reversed(f.readlines()[-500:]))
-
-        return ret
+        with open(TMP_LOGS_FILE) as f:
+            return "".join(reversed(f.readlines()[-500:]))

--- a/olaf/_internals/services/logs.py
+++ b/olaf/_internals/services/logs.py
@@ -11,7 +11,7 @@ from ...common.service import Service
 TMP_LOGS_FILE = "/tmp/olaf.log"
 
 
-def logger_tmp_file_setup(level: str):
+def logger_tmp_file_setup(level: str) -> None:
     """Get the boot log file handler and clean up temp log file used by LogsService."""
     if os.path.isfile(TMP_LOGS_FILE):
         os.remove(TMP_LOGS_FILE)
@@ -21,17 +21,17 @@ def logger_tmp_file_setup(level: str):
 class LogsService(Service):
     """Service for getting system logs"""
 
-    def __init__(self):
+    def __init__(self) -> None:
         super().__init__()
 
         self.logs_dir_path = "/var/log/journal/"
 
-    def on_start(self):
+    def on_start(self) -> None:
         self.node.od_write("logs", "make_file", False)  # make sure this is False by default
 
         self.node.add_sdo_callbacks("logs", "since_boot", self.on_read_since_boot, None)
 
-    def on_loop(self):
+    def on_loop(self) -> None:
         if self.node.od_read("logs", "make_file"):
             logger.info("Making a copy of logs")
 

--- a/olaf/_internals/services/os_command.py
+++ b/olaf/_internals/services/os_command.py
@@ -21,20 +21,20 @@ class OsCommandState(Enum):
 class OsCommandService(Service):
     """Service for running OS commands over CAN bus as defined by CiA 301 specs."""
 
-    def __init__(self):
+    def __init__(self) -> None:
         super().__init__()
 
         self.command = ""  # internal to prevent overwriting it when running a command
         self.reply_obj_max_len = 10000
         self.failed = False
 
-    def on_start(self):
+    def on_start(self) -> None:
         self._set_status_and_reply(OsCommandState.NO_ERROR_NO_REPLY.value, b"")
         self.node.add_sdo_callbacks(
             "os_command", "command", self.on_command_read, self.on_command_write
         )
 
-    def on_loop(self):
+    def on_loop(self) -> None:
         if self.node.od_read("os_command", "status") == OsCommandState.EXECUTING.value:
             logger.info("running os command: " + self.command)
 
@@ -58,7 +58,7 @@ class OsCommandService(Service):
 
         self.sleep(0.1)
 
-    def on_loop_error(self, error: Exception):
+    def on_loop_error(self, error: Exception) -> None:
         """On loop error set obj back to default."""
 
         self.failed = True
@@ -70,7 +70,7 @@ class OsCommandService(Service):
         """SDO read callback for command read."""
         return self.command.encode()
 
-    def on_command_write(self, command: bytes):
+    def on_command_write(self, command: bytes) -> None:
         """SDO write callback for command write."""
         if self.node.od_read("os_command", "status") == OsCommandState.EXECUTING.value:
             logger.error("cannot start another os command when one is running")
@@ -82,6 +82,6 @@ class OsCommandService(Service):
         self.command = command.decode()
         self._set_status_and_reply(OsCommandState.EXECUTING.value, b"")
 
-    def _set_status_and_reply(self, status: int, reply: bytes):
+    def _set_status_and_reply(self, status: int, reply: bytes) -> None:
         self.node.od_write("os_command", "status", status)
         self.node.od_write("os_command", "reply", reply)

--- a/olaf/_internals/services/updater.py
+++ b/olaf/_internals/services/updater.py
@@ -14,14 +14,13 @@ class UpdaterService(Service):
     def __init__(self, updater: Updater) -> None:
         super().__init__()
         self._updater = updater
-        hostname = os.uname()[1]
-        self._hostname = hostname[7:] if hostname.startswith("oresat-") else hostname
+        self._hostname = os.uname()[1].removeprefix("oresat-")
 
     def on_start(self) -> None:
 
         # make sure defaults are set correctly
-        self.node.od_write("updater", "update", False)
-        self.node.od_write("updater", "make_status_file", False)
+        self.node.od_write("updater", "update", value=False)
+        self.node.od_write("updater", "make_status_file", value=False)
 
         self.node.add_sdo_callbacks("updater", "status", self.on_read_status, None)
         self.node.add_sdo_callbacks("updater", "cache_files_json", self.on_read_cache_json, None)
@@ -42,13 +41,13 @@ class UpdaterService(Service):
                 self._updater.update()
             except UpdaterError as e:
                 logger.exception(e)
-            self.node.od_write("updater", "update", False)
+            self.node.od_write("updater", "update", value=False)
 
         # check for flag to make a status archive
         if self.node.od_read("updater", "make_status_file"):
             status_archive_file_path = self._updater.make_status_archive()
             self.node.fread_cache.add(status_archive_file_path, consume=True)
-            self.node.od_write("updater", "make_status_file", False)
+            self.node.od_write("updater", "make_status_file", value=False)
 
         self.sleep(0.1)
 

--- a/olaf/_internals/services/updater.py
+++ b/olaf/_internals/services/updater.py
@@ -11,13 +11,13 @@ from ..updater import Updater, UpdaterError
 class UpdaterService(Service):
     """Service for interacting with the updater"""
 
-    def __init__(self, updater: Updater):
+    def __init__(self, updater: Updater) -> None:
         super().__init__()
         self._updater = updater
         hostname = os.uname()[1]
         self._hostname = hostname[7:] if hostname.startswith("oresat-") else hostname
 
-    def on_start(self):
+    def on_start(self) -> None:
 
         # make sure defaults are set correctly
         self.node.od_write("updater", "update", False)
@@ -34,7 +34,7 @@ class UpdaterService(Service):
                 self.node.fwrite_cache.remove(i.name)
                 logger.info(f"updater moved {i.name} into update cache")
 
-    def on_loop(self):
+    def on_loop(self) -> None:
 
         # check for flag to start a update
         if self.node.od_read("updater", "update"):

--- a/olaf/_internals/updater.py
+++ b/olaf/_internals/updater.py
@@ -1,4 +1,5 @@
 """OreSat Linux updater"""
+
 from __future__ import annotations
 
 import json
@@ -67,7 +68,7 @@ class Updater:
     for easy to get status info while updating.
     """
 
-    def __init__(self, work_dir: str | Path, cache_dir: str | Path):
+    def __init__(self, work_dir: str | Path, cache_dir: str | Path) -> None:
         """
         Parameters
         ----------
@@ -100,7 +101,7 @@ class Updater:
         if not self._has_dpkg:
             logger.warning("dpkg is not installed, updates will not start")
 
-    def _clear_work_dir(self):
+    def _clear_work_dir(self) -> None:
         """Clear the working directory."""
 
         logger.info("clearing working directory")
@@ -133,7 +134,7 @@ class Updater:
 
         return ret
 
-    def update(self):
+    def update(self) -> None:
         """Run a update.
 
         If there are file aleady in the working directory, it will try to find
@@ -264,7 +265,7 @@ class Updater:
 
         return instructions_file_path
 
-    def _read_instructions(self) -> list:
+    def _read_instructions(self) -> list[str]:
         """Read the instructions file, validates the instructions, and makes the commands.
 
         Parameters
@@ -321,7 +322,7 @@ class Updater:
 
         return commands
 
-    def _run_instructions(self, commands: list):
+    def _run_instructions(self, commands: list[str]) -> None:
         """Run the instructions made by `_read_instructions.
 
         Parameters
@@ -402,7 +403,7 @@ class Updater:
 
         return olu_tar
 
-    def clear_cache(self):
+    def clear_cache(self) -> None:
         """Clear the update cache."""
 
         self._cache.clear()
@@ -420,7 +421,7 @@ class Updater:
         return self._state
 
     @property
-    def updates_cached(self) -> list:
+    def updates_cached(self) -> list[OreSatFile]:
         """list: The list of update archives in cache."""
 
         return self._cache.files()
@@ -462,7 +463,7 @@ class Updater:
         return self._command
 
 
-def is_update_archive(file_path: str) -> bool:
+def is_update_archive(file_path: str | Path) -> bool:
     """Check to see if the input is a valid update archive.
 
     Parameters

--- a/olaf/_internals/updater.py
+++ b/olaf/_internals/updater.py
@@ -256,8 +256,8 @@ class Updater:
         try:
             with tarfile.open(file_path, "r:xz") as t:
                 t.extractall(self._work_dir)
-        except tarfile.TarError:
-            raise UpdaterError(file_name + " is a invalid .tar.xz")
+        except tarfile.TarError as e:
+            raise UpdaterError(file_name + " is a invalid .tar.xz") from e
 
         instructions_file_path = self._work_dir + "/" + INSTRUCTIONS_FILE
         if not isfile(instructions_file_path):
@@ -290,13 +290,13 @@ class Updater:
         if not isfile(instructions_file_path):
             raise UpdaterError(f"cannot find {INSTRUCTIONS_FILE}")
 
-        with open(instructions_file_path, "r") as f:
+        with open(instructions_file_path) as f:
             instructions_str = f.read()
 
         try:
             instructions = json.loads(instructions_str)
-        except json.JSONDecodeError:
-            raise UpdaterError("instructions file was mising or did not contain a valid json")
+        except json.JSONDecodeError as e:
+            raise UpdaterError("instructions file was mising or did not contain valid json") from e
 
         # valid instructions and make commands
         for i in instructions:
@@ -482,7 +482,4 @@ def is_update_archive(file_path: str | Path) -> bool:
     except Exception:  # pylint: disable=W0718
         return False
 
-    if oresat_file.keyword == "update" and oresat_file.extension == ".tar.xz":
-        return True
-
-    return False
+    return oresat_file.keyword == "update" and oresat_file.extension == ".tar.xz"

--- a/olaf/board/adc.py
+++ b/olaf/board/adc.py
@@ -12,9 +12,9 @@ class Adc:
 
     ADC_VIN = 1.8  # volts
     ADC_BITS = 12
-    ADC_MAX_VALUE = (2**ADC_BITS) - 1
+    ADC_MAX_VALUE: int = (2**ADC_BITS) - 1
 
-    def __init__(self, pin: int, mock: bool = False):
+    def __init__(self, pin: int, mock: bool = False) -> None:
         """
         Parameters
         ----------

--- a/olaf/board/adc.py
+++ b/olaf/board/adc.py
@@ -43,10 +43,8 @@ class Adc:
         if not os.path.isfile(self._adc_path):
             raise AdcError(f"could not find ADC file {self._adc_path}")
 
-        with open(self._adc_path, "r") as f:
-            value = int(f.read())
-
-        return value
+        with open(self._adc_path) as f:
+            return int(f.read())
 
     @property
     def value(self) -> float:

--- a/olaf/board/cpufreq.py
+++ b/olaf/board/cpufreq.py
@@ -25,7 +25,7 @@ def get_cpufreq() -> int:
     return value
 
 
-def set_cpufreq(value: int):
+def set_cpufreq(value: int) -> None:
     """
     Set the current CPU frequency. Must be running as root to use this function.
 
@@ -62,7 +62,7 @@ def get_cpufreq_gov() -> str:
     return gov
 
 
-def set_cpufreq_gov(cpufreq_gov: str):
+def set_cpufreq_gov(cpufreq_gov: str) -> None:
     """
     Set the current cpu governor.
 

--- a/olaf/board/cpufreq.py
+++ b/olaf/board/cpufreq.py
@@ -20,9 +20,8 @@ def get_cpufreq() -> int:
         The current cpufreq in MHz.
     """
 
-    with open(f"{_CPU0_PATH}/scaling_cur_freq", "r") as f:
-        value = int(f.read()) // 1000
-    return value
+    with open(f"{_CPU0_PATH}/scaling_cur_freq") as f:
+        return int(f.read()) // 1000
 
 
 def set_cpufreq(value: int) -> None:
@@ -56,10 +55,8 @@ def get_cpufreq_gov() -> str:
         The current CPU governor.
     """
 
-    with open(f"{_CPU0_PATH}/scaling_governor", "r") as f:
-        gov = f.read().strip()
-
-    return gov
+    with open(f"{_CPU0_PATH}/scaling_governor") as f:
+        return f.read().strip()
 
 
 def set_cpufreq_gov(cpufreq_gov: str) -> None:

--- a/olaf/board/eeprom.py
+++ b/olaf/board/eeprom.py
@@ -16,7 +16,7 @@ class Eeprom:
         "A335OCFC": "cfc",
     }
 
-    def __init__(self):
+    def __init__(self) -> None:
         """
         Raises
         ------

--- a/olaf/board/gpio.py
+++ b/olaf/board/gpio.py
@@ -31,7 +31,7 @@ class Gpio:
         for i in os.listdir(_GPIO_DIR_PATH):
             if i.startswith("gpiochip") or i in ["export", "unexport"]:
                 continue
-            with open(f"{_GPIO_DIR_PATH}/{i}/label", "r") as f:
+            with open(f"{_GPIO_DIR_PATH}/{i}/label") as f:
                 _LABELS[f.read()[:-1]] = int(i[4:])  # remove the trailing '\n'
 
     def __init__(self, pin: str, mock: bool = False) -> None:
@@ -69,9 +69,9 @@ class Gpio:
             if not os.path.isdir(self._gpio_dir_path):
                 raise GpioError(f"gpio pin {self._name} (gpio{self._pin}) does not exist")
 
-            with open(f"{self._gpio_dir_path}/direction", "r") as f:
+            with open(f"{self._gpio_dir_path}/direction") as f:
                 self._mode = f.read()
-            with open(f"{self._gpio_dir_path}/label", "r") as f:
+            with open(f"{self._gpio_dir_path}/label") as f:
                 self._name = f.read()
 
     @property
@@ -97,10 +97,8 @@ class Gpio:
         if self._mock:
             return self._mock_value
 
-        with open(f"{self._gpio_dir_path}/value", "r") as f:
-            value = int(f.read())
-
-        return value
+        with open(f"{self._gpio_dir_path}/value") as f:
+            return int(f.read())
 
     @value.setter
     def value(self, new_value: int) -> None:

--- a/olaf/board/gpio.py
+++ b/olaf/board/gpio.py
@@ -34,7 +34,7 @@ class Gpio:
             with open(f"{_GPIO_DIR_PATH}/{i}/label", "r") as f:
                 _LABELS[f.read()[:-1]] = int(i[4:])  # remove the trailing '\n'
 
-    def __init__(self, pin: str, mock: bool = False):
+    def __init__(self, pin: str, mock: bool = False) -> None:
         """
         Parameters
         ----------
@@ -81,7 +81,7 @@ class Gpio:
         return self._mode
 
     @mode.setter
-    def mode(self, new_mode: str):
+    def mode(self, new_mode: str) -> None:
         if new_mode == self._mode:
             return  # already in the correct mode
 
@@ -103,7 +103,7 @@ class Gpio:
         return value
 
     @value.setter
-    def value(self, new_value: int):
+    def value(self, new_value: int) -> None:
         if self._mode == "in":
             raise GpioError(f"Cannot set GPIO {self.number} value, it is in input mode")
 
@@ -113,12 +113,12 @@ class Gpio:
             with open(f"{self._gpio_dir_path}/value", "w") as f:
                 f.write(str(new_value))
 
-    def high(self):
+    def high(self) -> None:
         """Set the GPIO high."""
 
         self.value = 1
 
-    def low(self):
+    def low(self) -> None:
         """Set the GPIO low."""
 
         self.value = 0

--- a/olaf/board/pru.py
+++ b/olaf/board/pru.py
@@ -25,7 +25,7 @@ class Pru:
     resources with the core processor.
     """
 
-    def __init__(self, pru_num: int):
+    def __init__(self, pru_num: int) -> None:
         """
         Parameters
         ----------
@@ -48,7 +48,7 @@ class Pru:
         self._pru_state_path = self._pru_dir_path + "/state"
         self._pru_fw_path = self._pru_dir_path + "/firmware"
 
-    def start(self):
+    def start(self) -> None:
         """
         Starts the PRU.
 
@@ -66,7 +66,7 @@ class Pru:
         with open(self._pru_state_path, "w") as f:
             f.write("start")
 
-    def stop(self):
+    def stop(self) -> None:
         """
         Stops the PRU.
 
@@ -84,7 +84,7 @@ class Pru:
             with open(self._pru_state_path, "w") as f:
                 f.write("stop")
 
-    def restart(self):
+    def restart(self) -> None:
         """Restarts the PRU."""
 
         self.stop()
@@ -137,7 +137,7 @@ class Pru:
         return fw_file
 
     @firmware.setter
-    def firmware(self, fw_path: str):
+    def firmware(self, fw_path: str) -> None:
         if self.state != PruState.OFFLINE:
             raise PruError(f"PRU{self._pru_num} must be in OFFLINE state to set firmware")
 

--- a/olaf/board/pru.py
+++ b/olaf/board/pru.py
@@ -96,7 +96,7 @@ class Pru:
 
         self.exists(raise_exception=True)
 
-        with open(self._pru_state_path, "r") as f:
+        with open(self._pru_state_path) as f:
             state = f.read()[:-1]  # drop the NULL terminator
 
         return PruState[state.upper()]
@@ -131,10 +131,8 @@ class Pru:
     def firmware(self) -> str:
         """str: Firmware file name selected. Must be in `/lib/firmware/`."""
 
-        with open(self._pru_fw_path, "r") as f:
-            fw_file = f.read()[:-1]  # drop the NULL terminator
-
-        return fw_file
+        with open(self._pru_fw_path) as f:
+            return f.read()[:-1]  # drop the NULL terminator
 
     @firmware.setter
     def firmware(self, fw_path: str) -> None:

--- a/olaf/canopen/master_node.py
+++ b/olaf/canopen/master_node.py
@@ -1,17 +1,25 @@
 """OreSat CANopen Master Node class to support the C3"""
 
-from collections import namedtuple
+from __future__ import annotations
+
 from time import monotonic
-from typing import Any, Dict, Union
+from typing import TYPE_CHECKING, NamedTuple
 
 import canopen
-from canopen.sdo import SdoArray, SdoRecord, SdoVariable
 from loguru import logger
 
-from ..canopen.network import CanNetwork
 from .node import Node
 
-NodeHeartbeatInfo = namedtuple("NodeHeartbeatInfo", ["state", "timestamp", "time_since_boot"])
+if TYPE_CHECKING:
+    from canopen.sdo import SdoArray, SdoRecord, SdoVariable
+
+    from ..canopen.network import CanNetwork
+
+
+class NodeHeartbeatInfo(NamedTuple):
+    state: int
+    timestamp: float
+    time_since_boot: float
 
 
 class MasterNode(Node):
@@ -21,8 +29,8 @@ class MasterNode(Node):
         self,
         network: CanNetwork,
         od: canopen.ObjectDictionary,
-        od_db: Dict[Any, canopen.ObjectDictionary],
-    ):
+        od_db: dict[str, canopen.ObjectDictionary],
+    ) -> None:
         """
         Parameters
         ----------
@@ -30,7 +38,7 @@ class MasterNode(Node):
             The CAN network
         od: canopen.ObjectDictionary
             The CANopen ObjectDictionary
-        od_db: Dict[Any, canopen.ObjectDictionary]
+        od_db: dict[str, canopen.ObjectDictionary]
             Database of other nodes's ODs. The dict key will be used by class fields and methods.
         """
 
@@ -56,7 +64,7 @@ class MasterNode(Node):
 
         self._network.add_reset_callback(self._restart_network)
 
-    def _restart_network(self):
+    def _restart_network(self) -> None:
         """Restart the CANopen network"""
 
         for key, od in self._od_db.items():
@@ -67,7 +75,7 @@ class MasterNode(Node):
         for remote_node in self._remote_nodes.values():
             self._network.add_node(remote_node)
 
-    def _on_heartbeat(self, cob_id: int, data: bytes, timestamp: float):
+    def _on_heartbeat(self, cob_id: int, data: bytes, timestamp: float) -> None:
         """Callback on node hearbeat messages."""
 
         node_id = cob_id - 0x700
@@ -75,14 +83,14 @@ class MasterNode(Node):
         key = self._node_id_to_key[node_id]
         self.node_status[key] = NodeHeartbeatInfo(status, timestamp, monotonic())
 
-    def _on_emergency(self, cob_id: int, data: bytes, timestamp: float):  # pylint: disable=W0613
+    def _on_emergency(self, cob_id: int, data: bytes, timestamp: float) -> None:
         """Callback on node emergency messages."""
 
         node_id = cob_id - 0x80
         value_str = data.hex(sep=" ")
         logger.error(f"node {node_id:02X} raised emergency: {value_str}")
 
-    def send_sync(self):
+    def send_sync(self) -> None:
         """
         Send a CANopen SYNC message.
         """
@@ -90,32 +98,32 @@ class MasterNode(Node):
         self._network.send_message(0x80, b"", False)
 
     @property
-    def remote_nodes(self) -> dict[Any, canopen.RemoteNode]:
-        """dict[Any, canopen.RemoteNode]: All other node as remote node."""
+    def remote_nodes(self) -> dict[str, canopen.RemoteNode]:
+        """All other node as remote node."""
         return self._remote_nodes
 
     @property
-    def od_db(self) -> dict[Any, canopen.ObjectDictionary]:
-        """dict[Any, canopen.ObjectDictionary]: All other node ODs."""
+    def od_db(self) -> dict[str, canopen.ObjectDictionary]:
+        """All other node ODs."""
         return self._od_db
 
     def _sdo_get_obj(
-        self, key: Any, index: Union[int, str], subindex: Union[int, str, None]
-    ) -> [SdoVariable, SdoArray, SdoRecord]:
+        self, key: str, index: int | str, subindex: int | str | None
+    ) -> SdoVariable | SdoArray | SdoRecord:
 
         if subindex is None:
             return self._remote_nodes[key].sdo[index]
         return self._remote_nodes[key].sdo[index][subindex]
 
     def sdo_read(
-        self, key: Any, index: Union[int, str], subindex: Union[int, str, None]
-    ) -> Union[int, str, float, bytes, bool]:
+        self, key: str, index: int | str, subindex: int | str | None
+    ) -> str | float | bytes | bool:
         """
         Read a value from a remote node's object dictionary using an SDO.
 
         Parameters
         ----------
-        key: Any
+        key: str
             The dict key for the node to read from.
         index: int | str
             The index to read from.
@@ -138,14 +146,14 @@ class MasterNode(Node):
         return self._sdo_get_obj(key, index, subindex).phys
 
     def sdo_read_bitfield(
-        self, key: Any, index: Union[int, str], subindex: Union[int, str, None], field: str
+        self, key: str, index: int | str, subindex: int | str | None, field: str
     ) -> int:
         """
         Read an field from a object from another node's OD using a SDO.
 
         Parameters
         ----------
-        key: Any
+        key: str
             The dict key for the node to read from.
         index: int | str
             The index to read from.
@@ -175,15 +183,13 @@ class MasterNode(Node):
             value |= tmp >> bits[i]
         return value
 
-    def sdo_read_enum(
-        self, key: Any, index: Union[int, str], subindex: Union[int, str, None]
-    ) -> str:
+    def sdo_read_enum(self, key: str, index: int | str, subindex: int | str | None) -> str:
         """
         Read an enum str from another node's OD using a SDO.
 
         Parameters
         ----------
-        key: Any
+        key: str
             The dict key for the node to read from.
         index: int | str
             The index to read from.
@@ -209,17 +215,17 @@ class MasterNode(Node):
 
     def sdo_write(
         self,
-        key: Any,
-        index: Union[int, str],
-        subindex: Union[int, str, None],
-        value: Union[int, str, float, bytes, bool],
-    ):
+        key: str,
+        index: int | str,
+        subindex: int | str | None,
+        value: str | float | bytes | bool,
+    ) -> None:
         """
         Write a value to a remote node's object dictionary using an SDO.
 
         Parameters
         ----------
-        key: Any
+        key: str
             The dict key for the  node to write to.
         index: int | int
             The index to write to.
@@ -241,18 +247,18 @@ class MasterNode(Node):
 
     def sdo_write_bitfield(
         self,
-        key: Any,
-        index: Union[int, str],
-        subindex: Union[int, str, None],
+        key: str,
+        index: int | str,
+        subindex: int | str | None,
         field: str,
         value: int,
-    ):  # pylint: disable=R0917
+    ) -> None:
         """
         Write a field from a object to another node's OD using a SDO.
 
         Parameters
         ----------
-        key: Any
+        key: str
             The dict key for the  node to write to.
         index: int | int
             The index to write to.
@@ -285,14 +291,14 @@ class MasterNode(Node):
         obj.phys = new_value
 
     def sdo_write_enum(
-        self, key: Any, index: Union[int, str], subindex: Union[int, str, None], value: str
-    ):
+        self, key: str, index: int | str, subindex: int | str | None, value: str
+    ) -> None:
         """
         Write a enum str to another node's OD using a SDO.
 
         Parameters
         ----------
-        key: Any
+        key: str
             The dict key for the  node to write to.
         index: int | int
             The index to write to.
@@ -313,7 +319,7 @@ class MasterNode(Node):
         tmp = {d: v for v, d in obj.od.value_descriptions}
         obj.phys = tmp[value]
 
-    def send_rpdo(self, rpdo: int, raise_error: bool = True):
+    def send_rpdo(self, rpdo: int, raise_error: bool = True) -> None:
         """
         Send a RPDO. Will not be sent if not node is not in operational state.
 

--- a/olaf/canopen/master_node.py
+++ b/olaf/canopen/master_node.py
@@ -95,7 +95,7 @@ class MasterNode(Node):
         Send a CANopen SYNC message.
         """
 
-        self._network.send_message(0x80, b"", False)
+        self._network.send_message(0x80, b"", raise_error=False)
 
     @property
     def remote_nodes(self) -> dict[str, canopen.RemoteNode]:

--- a/olaf/canopen/network.py
+++ b/olaf/canopen/network.py
@@ -1,9 +1,11 @@
 """CAN network"""
 
+from __future__ import annotations
+
 import os
 import subprocess
 from enum import IntEnum, auto
-from typing import Callable, Union
+from typing import Callable
 
 import can
 import canopen
@@ -36,7 +38,7 @@ class CanNetwork:
         channel: str,
         socketcand_host: str = "localhost",
         socketcand_port: int = 29536,
-    ):
+    ) -> None:
         self._bus_type = bus_type
         self._channel = channel
         self._socketcand_host = socketcand_host
@@ -45,9 +47,9 @@ class CanNetwork:
         self._reset_cbs: list[Callable[[], None]] = []
         self._nodes: list[canopen.Node] = []
         self._subscriptions: list[tuple[int, Callable[[int, bytes, float], None]]] = []
-        self._bus: Union[can.BusABC, None] = None
-        self._network: Union[canopen.Network, None] = None
-        self._notifier = None
+        self._bus: can.BusABC | None = None
+        self._network: canopen.Network | None = None
+        self._notifier: can.Notifier | None = None
 
         self._state = CanNetworkState.NETWORK_INIT
 
@@ -57,10 +59,10 @@ class CanNetwork:
         self._first_no_bus = True  # flag to only log error message on _first error
         self._first_bus_down = True  # flag to only log error message on _first error
 
-    def __del__(self):
+    def __del__(self) -> None:
         self._del()
 
-    def _init(self):
+    def _init(self) -> None:
         logger.info("(re)starting CAN network")
         try:
             self._bus = can.interface.Bus(
@@ -74,7 +76,7 @@ class CanNetwork:
             return
 
         self._network = canopen.Network(self._bus)
-        self._notifier = can.Notifier(self._network.bus, self._network.listeners, 1)
+        self._notifier = can.Notifier(self._bus, self._network.listeners, 1)
         self._network.notifier = self._notifier
         try:
             for sub in self._subscriptions:
@@ -84,7 +86,7 @@ class CanNetwork:
         except Exception as e:  # pylint: disable=W0718
             logger.exception(e)
 
-    def _del(self):
+    def _del(self) -> None:
         if self._network is not None:
             try:
                 self._network.disconnect()
@@ -103,7 +105,7 @@ class CanNetwork:
             del self._bus
             self._bus = None
 
-    def _restart_bus(self):
+    def _restart_bus(self) -> None:
         """Try to restart the CAN bus"""
 
         if self._bus:
@@ -120,7 +122,7 @@ class CanNetwork:
             if out.returncode != 0:
                 logger.error(out)
 
-    def monitor(self):
+    def monitor(self) -> None:
         """Monitor the CAN bus/network"""
 
         if self._bus_type == "socketcand":
@@ -130,7 +132,6 @@ class CanNetwork:
             return
 
         bus = psutil.net_if_stats().get(self._channel)
-        bus_exist = bus is not None
 
         if self._state == CanNetworkState.NETWORK_INIT:
             self._init()
@@ -139,13 +140,13 @@ class CanNetwork:
             if self._first_no_bus:
                 logger.critical(f"{self._channel} does not exists, nothing OLAF can do")
                 self._first_no_bus = False
-            if bus_exist:
+            if bus is None:
                 self._state = CanNetworkState.NETWORK_DOWN
         elif self._state == CanNetworkState.NETWORK_DOWN:
             if self._first_bus_down:
                 logger.error(f"{self._channel} is down")
                 self._first_bus_down = False
-            if not bus_exist:
+            if bus is None:
                 self._first_no_bus = True  # reset flag
                 self._del()
                 self._state = CanNetworkState.NETWORK_NO_BUS
@@ -156,7 +157,7 @@ class CanNetwork:
                 self._init()
                 self._state = CanNetworkState.NETWORK_UP
         elif self._state == CanNetworkState.NETWORK_UP:
-            if not bus_exist:
+            if bus is None:
                 self._first_no_bus = True  # reset flag
                 self._del()
                 self._state = CanNetworkState.NETWORK_NO_BUS
@@ -165,7 +166,7 @@ class CanNetwork:
                 self._del()
                 self._state = CanNetworkState.NETWORK_DOWN
 
-    def add_reset_callback(self, reset_cb: Callable[[], None]):
+    def add_reset_callback(self, reset_cb: Callable[[], None]) -> None:
         """Add CAN bus/network reset callback."""
         if self._network is not None:
             reset_cb()
@@ -176,7 +177,7 @@ class CanNetwork:
         """CanState: CAN bus state."""
         return self._state
 
-    def send_message(self, cob_id: int, data: bytes, raise_error: bool = True):
+    def send_message(self, cob_id: int, data: bytes, raise_error: bool = True) -> None:
         """Send a CAN message."""
 
         try:
@@ -188,13 +189,13 @@ class CanNetwork:
             if raise_error:
                 raise CanNetworkError(str(e)) from e
 
-    def subscribe(self, cob_id: int, callback: Callable[[int, bytes, float], None]):
+    def subscribe(self, cob_id: int, callback: Callable[[int, bytes, float], None]) -> None:
         """Subscribe to CAN messages by the cob_id."""
         if self._network is not None:
             self._network.subscribe(cob_id, callback)
         self._subscriptions.append((cob_id, callback))
 
-    def add_node(self, node: canopen.Node):
+    def add_node(self, node: canopen.LocalNode | canopen.RemoteNode) -> None:
         """Add a node to the network."""
         if self._network is not None:
             self._network.add_node(node)

--- a/olaf/canopen/network.py
+++ b/olaf/canopen/network.py
@@ -90,8 +90,8 @@ class CanNetwork:
         if self._network is not None:
             try:
                 self._network.disconnect()
-            except Exception:  # pylint: disable=W0718
-                pass
+            except Exception as e:  # pylint: disable=W0718
+                logger.info(f"Error when disconnecting: {e}")
             del self._network
             self._network = None
 
@@ -179,12 +179,12 @@ class CanNetwork:
 
     def send_message(self, cob_id: int, data: bytes, raise_error: bool = True) -> None:
         """Send a CAN message."""
-
-        try:
-            if self._bus is not None:
-                self._bus.send(can.Message(arbitration_id=cob_id, data=data, is_extended_id=False))
-            elif raise_error:
+        if self._bus is None:
+            if raise_error:
                 raise CanNetworkError("can network is down")
+            return
+        try:
+            self._bus.send(can.Message(arbitration_id=cob_id, data=data, is_extended_id=False))
         except Exception as e:  # pylint: disable=W0718
             if raise_error:
                 raise CanNetworkError(str(e)) from e

--- a/olaf/canopen/node.py
+++ b/olaf/canopen/node.py
@@ -1,12 +1,14 @@
 """OreSat CANopen Node"""
 
+from __future__ import annotations
+
 import os
 import struct
 from enum import IntEnum
 from pathlib import Path
 from threading import Event
 from time import monotonic
-from typing import Any, Callable, Dict, Union
+from typing import TYPE_CHECKING, Any
 
 from canopen import LocalNode, ObjectDictionary
 from canopen.objectdictionary import (
@@ -25,6 +27,9 @@ from ..canopen.network import CanNetwork, CanNetworkState
 from ..common.daemon import Daemon
 from ..common.oresat_file_cache import OreSatFileCache
 from . import EmcyCode
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
 
 
 class NodeStop(IntEnum):
@@ -61,7 +66,7 @@ class Node:
     basic API for CANopen things.
     """
 
-    def __init__(self, network: CanNetwork, od: ObjectDictionary):
+    def __init__(self, network: CanNetwork, od: ObjectDictionary) -> None:
         """
         Parameters
         ----------
@@ -73,13 +78,13 @@ class Node:
 
         self._event = Event()
         self._od = od
-        self._node: LocalNode = None
+        self._node: LocalNode | None = None
         self._network: CanNetwork = network
-        self._read_cbs = {}  # type: ignore
-        self._write_cbs = {}  # type: ignore
+        self._read_cbs: dict[tuple[str, str | None], Callable[[], Any]] = {}
+        self._write_cbs: dict[tuple[str, str | None], Callable[[Any], None]] = {}
         self._syncs = 0
         self._reset = NodeStop.SOFT_RESET
-        self._daemons = {}  # type: ignore
+        self._daemons: dict[str, Daemon] = {}
 
         if os.geteuid() == 0:  # running as root
             self.work_base_dir = "/var/lib/oresat"
@@ -109,12 +114,12 @@ class Node:
             self._rpdo_cobid_to_num[cob_id] = i
             self._network.subscribe(cob_id, self._on_pdo)
 
-    def __del__(self):
+    def __del__(self) -> None:
         # stop the monitor thread if it is running
         if not self._event.is_set():
             self.stop()
 
-    def _on_sync(self, cob_id: int, data: bytes, timestamp: float):  # pylint: disable=W0613
+    def _on_sync(self, cob_id: int, data: bytes, timestamp: float) -> None:
         """On SYNC message send TPDOs configured to be SYNC-based"""
 
         self._syncs += 1
@@ -126,7 +131,7 @@ class Node:
             if self._syncs % transmission_type == 0:
                 self.send_tpdo(i)
 
-    def _on_pdo(self, cob_id: int, data: bytes, timestamp: float):  # pylint: disable=W0613
+    def _on_pdo(self, cob_id: int, data: bytes, timestamp: float) -> None:
         rpdo = self._rpdo_cobid_to_num[cob_id]
         maps = self.od[0x1600 + rpdo][0].value
 
@@ -149,7 +154,7 @@ class Node:
 
             offset += size
 
-    def _setup_node(self):
+    def _setup_node(self) -> None:
         """Create the CANopen node."""
 
         if self._od.node_id is None:
@@ -167,7 +172,7 @@ class Node:
         else:
             self._first_network_reset = False
 
-    def _destroy_node(self):
+    def _destroy_node(self) -> None:
         """Destroy the CANopen node."""
 
         self._node = None
@@ -220,14 +225,14 @@ class Node:
         logger.info(f"{self.name} node has ended")
         return self._reset
 
-    def stop(self, reset: Union[NodeStop, None] = None):
+    def stop(self, reset: NodeStop | None = None) -> None:
         """End the run loop"""
 
         if reset is not None:
             self._reset = reset
         self._event.set()
 
-    def add_daemon(self, name: str):
+    def add_daemon(self, name: str) -> None:
         """Add a daemon for the node to monitor and/or control"""
 
         self._daemons[name] = Daemon(name)
@@ -235,20 +240,20 @@ class Node:
     def add_sdo_callbacks(
         self,
         index: str,
-        subindex: str,
-        read_cb: Callable[[None], Any],
-        write_cb: Callable[[Any], None],
-    ):
+        subindex: str | None,
+        read_cb: Callable[[], Any] | None,
+        write_cb: Callable[[Any], None] | None,
+    ) -> None:
         """
         Add an SDO read callback for a variable at index and optional subindex.
 
         Parameters
         ----------
-        index: int or str
+        index: str
             The index to call the callback on.
-        subindex: int or str
+        subindex: str
             The subindex to call the callback on.
-        read_cb: Callable[[None], Any]
+        read_cb: Callable[[], Any]
             The SDO read callback. Allows overriding the data being sent on a SDO read. If
             overriding read data return the value or return :py:data:`None` to use the the value
             from the od. Set to :py:data:`None` for no read_cb.
@@ -279,7 +284,7 @@ class Node:
         if write_cb is not None:
             self._write_cbs[index, subindex] = write_cb
 
-    def _send_pdo(self, comm_index: int, map_index: int, raise_error: bool = True):
+    def _send_pdo(self, comm_index: int, map_index: int, raise_error: bool = True) -> None:
         """Send a PDO. Will not be sent if not node is not in operational state."""
 
         # PDOs should not be sent if CANopen node not in 'OPERATIONAL' state
@@ -316,7 +321,7 @@ class Node:
 
         self._network.send_message(cob_id, data, raise_error)
 
-    def send_tpdo(self, tpdo: int, raise_error: bool = True):
+    def send_tpdo(self, tpdo: int, raise_error: bool = True) -> None:
         """
         Send a TPDO. Will not be sent if not node is not in operational state.
 
@@ -340,7 +345,7 @@ class Node:
         map_index = 0x1A00 + tpdo
         self._send_pdo(comm_index, map_index, raise_error)
 
-    def send_emcy(self, code: Union[EmcyCode, int], data: bytes = b"", raise_error: bool = True):
+    def send_emcy(self, code: EmcyCode | int, data: bytes = b"", raise_error: bool = True) -> None:
         """
         Send a EMCY message.
 
@@ -370,7 +375,9 @@ class Node:
         self._network.send_message(self.od.node_id + 0x80, frame, raise_error)
         logger.error(f"sent emcy 0x{code:04X} {data.hex()}")
 
-    def _on_sdo_read(self, index: int, subindex: int, od: ODVariable):
+    def _on_sdo_read(
+        self, index: int, subindex: int, od: ODVariable
+    ) -> int | str | float | bytes | bool:
         """
         SDO read callback function. Allows overriding the data being sent on a SDO read. Return
         valid datatype for object, if overriding read data, or :py:data:`None` to use the the value
@@ -395,14 +402,14 @@ class Node:
 
         # convert any ints to strs
         if isinstance(self.od[index], ODVariable) and od == self.od[index]:
-            index = od.name
-            subindex = None  # type: ignore
+            index_name = od.name
+            subindex_name: str | None = None
         else:
-            index = self.od[index].name
-            subindex = od.name
+            index_name = self.od[index].name
+            subindex_name = od.name
 
-        if (index, subindex) in self._read_cbs:
-            ret = self._read_cbs[index, subindex]()
+        if (index_name, subindex_name) in self._read_cbs:
+            ret = self._read_cbs[index_name, subindex_name]()
 
         # get value from OD
         if ret is None:
@@ -410,7 +417,13 @@ class Node:
 
         return ret
 
-    def _on_sdo_write(self, index: int, subindex: int, od: ODVariable, data: bytes):
+    def _on_sdo_write(
+        self,
+        index: int | str,
+        subindex: int | str | None,
+        od: ODVariable,
+        data: str | float | bytes | bool,
+    ) -> None:
         """
         SDO write callback function. Gives access to the data being received on a SDO write.
 
@@ -418,34 +431,35 @@ class Node:
 
         Parameters
         ----------
-        index: int
+        index:
             The index the SDO being written to.
-        subindex: int
+        subindex:
             The subindex the SDO being written to.
-        od: canopen.objectdictionary.ODVariable
+        od:
             The variable object being written to. Badly named.
-        data: bytes
+        data:
             The raw data being written.
         """
 
         binary_types = [DOMAIN, OCTET_STRING]
+        obj = od
 
         # set value in OD before callback
-        if od.data_type in binary_types:
-            od.value = data
+        if obj.data_type in binary_types:
+            obj.value = data
         else:
-            od.value = od.decode_raw(data)
+            obj.value = obj.decode_raw(data)
 
         # convert any ints to strs
-        if isinstance(self.od[index], ODVariable) and od == self.od[index]:
-            index = od.name
-            subindex = None  # type: ignore
+        if isinstance(self.od[index], ODVariable) and obj == self.od[index]:
+            index = obj.name
+            subindex = None
         else:
             index = self.od[index].name
-            subindex = od.name
+            subindex = obj.name
 
         if (index, subindex) in self._write_cbs:
-            self._write_cbs[index, subindex](od.value)
+            self._write_cbs[index, subindex](obj.value)
 
     @property
     def bus(self) -> str:
@@ -490,14 +504,14 @@ class Node:
         return not self._event.is_set()
 
     @property
-    def daemons(self) -> Dict[str, Daemon]:
+    def daemons(self) -> dict[str, Daemon]:
         """dict: The dictionary of external daemons that are monitored and/or controllable"""
 
         return self._daemons
 
     def od_get_obj(
-        self, index: Union[int, str], subindex: Union[int, str, None] = None
-    ) -> Union[ODVariable, ODArray, ODRecord]:
+        self, index: int | str, subindex: int | str | None = None
+    ) -> ODVariable | ODArray | ODRecord:
         """
         Quick helper function to get an object from the od.
 
@@ -512,8 +526,8 @@ class Node:
         return self._od[index][subindex]
 
     def od_read(
-        self, index: Union[int, str], subindex: Union[int, str, None]
-    ) -> Union[int, str, float, bytes, bool]:
+        self, index: int | str, subindex: int | str | None
+    ) -> int | str | float | bytes | bool:
         """
         Read a value from the OD.
 
@@ -533,9 +547,7 @@ class Node:
         obj = self.od_get_obj(index, subindex)
         return obj.value
 
-    def od_read_bitfield(
-        self, index: Union[int, str], subindex: Union[int, str, None], field: str
-    ) -> int:
+    def od_read_bitfield(self, index: int | str, subindex: int | str | None, field: str) -> int:
         """
         Read a field from a object from the OD.
 
@@ -561,7 +573,7 @@ class Node:
             value |= tmp >> bits[i]
         return value
 
-    def od_read_enum(self, index: Union[int, str], subindex: Union[int, str, None]) -> str:
+    def od_read_enum(self, index: int | str, subindex: int | str | None) -> str:
         """
         Read a enum str from the OD.
 
@@ -581,15 +593,12 @@ class Node:
         obj = self.od_get_obj(index, subindex)
         return obj.value_descriptions[obj.value]
 
-    def _var_write(self, obj: ODVariable, value: Union[int, str, float, bytes, bool]):
-
-        value_type = type(value)
-
-        def make_error_value(data_type) -> str:
+    def _var_write(self, obj: ODVariable, value: str | float | bytes | bool) -> None:
+        def make_error_value(data_type: str) -> str:
             return f"cannot write {value!r} ({data_type}) to object {obj.name} ({obj.data_type})"
 
         if obj.data_type in INTEGER_TYPES:
-            if value_type != int:
+            if not isinstance(value, int):
                 raise TypeError(make_error_value("int"))
             if obj.max is not None and value > obj.max:
                 raise ValueError(f"value {value!r} too high (high limit {obj.max})")
@@ -611,10 +620,10 @@ class Node:
 
     def od_write(
         self,
-        index: Union[int, str],
-        subindex: Union[int, str, None],
-        value: Union[int, str, float, bytes, bool],
-    ):
+        index: int | str,
+        subindex: int | str | None,
+        value: str | float | bytes | bool,
+    ) -> None:
         """
         Write an value to the OD.
 
@@ -637,8 +646,8 @@ class Node:
         self._var_write(obj, value)
 
     def od_write_bitfield(
-        self, index: Union[int, str], subindex: Union[int, str, None], field: str, value: int
-    ):
+        self, index: int | str, subindex: int | str | None, field: str, value: int
+    ) -> None:
         """
         Write a bit field value to a object to the OD.
 
@@ -672,7 +681,7 @@ class Node:
         new_value |= value << offset
         obj.value = new_value
 
-    def od_write_enum(self, index: Union[int, str], subindex: Union[int, str, None], value: str):
+    def od_write_enum(self, index: int | str, subindex: int | str | None, value: str) -> None:
         """
         Write a enum str to the OD.
 
@@ -687,5 +696,5 @@ class Node:
         """
 
         obj = self.od_get_obj(index, subindex)
-        tmp = {d: v for v, d in obj.value_descriptions}
+        tmp = {d: v for v, d in obj.value_descriptions.items()}
         obj.value = tmp[value.lower()]

--- a/olaf/canopen/node.py
+++ b/olaf/canopen/node.py
@@ -205,7 +205,7 @@ class Node:
             # send heartbeat
             event_time = self.od[0x1017].value
             if loops % (event_time // delay_ms) == 0:
-                self._network.send_message(0x700 + self.od.node_id, b"\x05", False)
+                self._network.send_message(0x700 + self.od.node_id, b"\x05", raise_error=False)
 
             # send all timer-based TPDOs
             for i in range(self._od.device_information.nr_of_TXPDO):
@@ -316,7 +316,7 @@ class Node:
             data += value_bytes
 
         if len(data) > 8:
-            self.send_emcy(EmcyCode.PROTOCOL_PDO_LEN_EXCEEDED, b"", False)
+            self.send_emcy(EmcyCode.PROTOCOL_PDO_LEN_EXCEEDED, b"", raise_error=False)
             return
 
         self._network.send_message(cob_id, data, raise_error)

--- a/olaf/common/__init__.py
+++ b/olaf/common/__init__.py
@@ -1,5 +1,7 @@
 """Common OLAF class and functions."""
 
+from __future__ import annotations
+
 import re
 
 
@@ -23,15 +25,14 @@ def natsorted(data: list[str], ignore_case: bool = False) -> list[str]:
     if not data:
         return []
 
-    def convert(text):
-        r = text
+    def convert(text: str) -> int | str:
         if text.isdigit():
-            r = int(text)
-        elif ignore_case:
-            text.lower()
-        return r
+            return int(text)
+        if ignore_case:
+            return text.lower()
+        return text
 
-    def alphanum_key(key):
+    def alphanum_key(key: str) -> list[int | str]:
         return [convert(c) for c in re.split("([0-9]+)", str(key))]
 
     return sorted(data, key=alphanum_key)

--- a/olaf/common/daemon.py
+++ b/olaf/common/daemon.py
@@ -22,7 +22,7 @@ class DaemonState(Enum):
 class Daemon:
     """Quick class to control a systemd daemon."""
 
-    def __init__(self, name: str):
+    def __init__(self, name: str) -> None:
         """
         Parameters
         ----------
@@ -32,17 +32,17 @@ class Daemon:
 
         self._name = name
 
-    def start(self):
+    def start(self) -> None:
         """Start the daemon."""
 
         subprocess.run(f"systemctl start {self._name}", shell=True, check=False)
 
-    def stop(self):
+    def stop(self) -> None:
         """Stop the daemon."""
 
         subprocess.run(f"systemctl stop {self._name}", shell=True, check=False)
 
-    def restart(self):
+    def restart(self) -> None:
         """Restart the daemon."""
 
         subprocess.run(f"systemctl restart {self._name}", shell=True, check=False)

--- a/olaf/common/oresat_file.py
+++ b/olaf/common/oresat_file.py
@@ -1,10 +1,14 @@
 """File name format for OreSat files"""
+
 from __future__ import annotations
 
-from pathlib import Path
 from os import uname
 from os.path import basename
 from time import time
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from pathlib import Path
 
 
 def new_oresat_file(keyword: str, card: str = "", date: float = -1.0, ext: str = "") -> str:
@@ -87,10 +91,10 @@ class OreSatFile:
     def __str__(self) -> str:
         return self._name
 
-    def __lt__(self, other: 'OreSatFile') -> bool:
+    def __lt__(self, other: OreSatFile) -> bool:
         return self._date < other.date
 
-    def __gt__(self, other: 'OreSatFile') -> bool:
+    def __gt__(self, other: OreSatFile) -> bool:
         return self._date > other.date
 
     @property

--- a/olaf/common/oresat_file_cache.py
+++ b/olaf/common/oresat_file_cache.py
@@ -42,9 +42,7 @@ class OreSatFileCache:
 
     def __len__(self) -> int:
         with self._lock:
-            length = len(self._data)
-
-        return length
+            return len(self._data)
 
     def add(self, file_path: str | Path, consume: bool = False) -> None:
         """Add file to cache
@@ -106,12 +104,7 @@ class OreSatFileCache:
         """
 
         with self._lock:
-            if len(self._data) > 0:
-                oldest_file = self._data[0].name
-            else:
-                oldest_file = ""
-
-        return oldest_file
+            return self._data[0].name if len(self._data) > 0 else ""
 
     def pop(self, dir_path: str | Path, copy: bool = False) -> str:
         """Pop the oldest file from the cache

--- a/olaf/common/oresat_file_cache.py
+++ b/olaf/common/oresat_file_cache.py
@@ -1,4 +1,5 @@
 """File cache class for OreSat files."""
+
 from __future__ import annotations
 
 import shutil
@@ -45,7 +46,7 @@ class OreSatFileCache:
 
         return length
 
-    def add(self, file_path: str | Path, consume: bool = False):
+    def add(self, file_path: str | Path, consume: bool = False) -> None:
         """Add file to cache
 
         Parameters
@@ -80,7 +81,7 @@ class OreSatFileCache:
                 self._data.append(oresat_file)
                 self._data = sorted(self._data)
 
-    def remove(self, file_name: str):
+    def remove(self, file_name: str) -> None:
         """Remove a file from cache
 
         Parameters
@@ -214,7 +215,7 @@ class OreSatFileCache:
 
         return files
 
-    def clear(self):
+    def clear(self) -> None:
         """Clear all file in the cache"""
 
         with self._lock:

--- a/olaf/common/resource.py
+++ b/olaf/common/resource.py
@@ -12,11 +12,11 @@ class Resource:
     All the ``on_*`` members can be overridden as needed.
     """
 
-    def __init__(self):
-        self.node = None
+    def __init__(self) -> None:
+        self.node: Node = None
         """Node or MasterNode: The app's CANopen node. Set to None until start() is called."""
 
-    def start(self, node: Node):
+    def start(self, node: Node) -> None:
         """
         App will call this to start the resource. This will call `self.on_start()`.
         """
@@ -28,10 +28,10 @@ class Resource:
             self.on_start()
         except Exception as e:  # pylint: disable=W0718
             logger.exception(
-                f"{self.__class__.__name__}'s on_start raised an uncaught exception:" f"{e}"
+                f"{self.__class__.__name__}'s on_start raised an uncaught exception:{e}"
             )
 
-    def end(self):
+    def end(self) -> None:
         """
         App will call this to stop the resource. This will call `self.on_end()`.
         """
@@ -41,9 +41,7 @@ class Resource:
         try:
             self.on_end()
         except Exception as e:  # pylint: disable=W0718
-            logger.exception(
-                f"{self.__class__.__name__}'s on_end raised an uncaught exception:" f"{e}"
-            )
+            logger.exception(f"{self.__class__.__name__}'s on_end raised an uncaught exception:{e}")
 
     def on_start(self) -> None:
         """

--- a/olaf/common/resource.py
+++ b/olaf/common/resource.py
@@ -48,10 +48,6 @@ class Resource:
         Start the resource.
         """
 
-        pass
-
     def on_end(self) -> None:
         """Called when the program ends and if the resources fails. Should be used to stop hardware
         and can be used to zero/clear resource's data in object dictionary as needed."""
-
-        pass

--- a/olaf/common/service.py
+++ b/olaf/common/service.py
@@ -71,8 +71,6 @@ class Service:
         Should be used to add SDO read/write callbacks to app.
         """
 
-        pass
-
     def _loop(self) -> None:
         """
         Loop until a exception is thrown or the app stops.
@@ -143,8 +141,6 @@ class Service:
         Will be called reguardless if `self.on_loop_error()` was called or not when the app stops.
         """
 
-        pass
-
     def on_stop(self) -> None:
         """
         Called when the app stops after the thread has stopped. Should be used to stop any hardware
@@ -152,8 +148,6 @@ class Service:
 
         Will be called reguardless if `self.on_loop_error()` was called or not when the app stops.
         """
-
-        pass
 
     def sleep(self, timeout: float) -> None:
         """

--- a/olaf/common/service.py
+++ b/olaf/common/service.py
@@ -30,8 +30,8 @@ class Service:
     All the ``on_*`` members can be overridden as needed.
     """
 
-    def __init__(self):
-        self.node = None
+    def __init__(self) -> None:
+        self.node: Node = None
         """Node or MasterNode: The app's CANopen node. Set to None until start() is called."""
 
         self._event = Event()
@@ -39,14 +39,14 @@ class Service:
         self._status = ServiceState.STOPPED
         self._error = False
 
-    def __del__(self):
+    def __del__(self) -> None:
         if not self._event.is_set():
             self._event.set()
 
         if self._thread.is_alive():
             self._thread.join()
 
-    def start(self, node: Node):
+    def start(self, node: Node) -> None:
         """
         App will call this to start the service. This will call `self.on_start()` start a thread
         that will call `self.on_loop()`.
@@ -64,7 +64,7 @@ class Service:
             logger.critical(f"{self.__class__.__name__}'s thread is being skipped")
             self._status = ServiceState.FAILED
 
-    def on_start(self):
+    def on_start(self) -> None:
         """
         Called when the service starts.
 
@@ -73,7 +73,7 @@ class Service:
 
         pass
 
-    def _loop(self):
+    def _loop(self) -> None:
         """
         Loop until a exception is thrown or the app stops.
         """
@@ -91,14 +91,14 @@ class Service:
 
         self._status = ServiceState.STOPPING
 
-    def on_loop(self):
+    def on_loop(self) -> None:
         """
         Called when in a while loop.
         """
 
         self.sleep(1)
 
-    def on_loop_error(self, error: Exception):
+    def on_loop_error(self, error: Exception) -> None:
         """
         Called when on_loop raises an exception before the thread stops.
 
@@ -107,7 +107,7 @@ class Service:
 
         logger.exception(f"{self.__class__.__name__} on_loop raised: {error}")
 
-    def stop(self):
+    def stop(self) -> None:
         """
         App will call this to stop the service when the app stops. This will call `self.on_stop()`.
         """
@@ -135,7 +135,7 @@ class Service:
 
         self._status = ServiceState.FAILED if self._error else ServiceState.STOPPED
 
-    def on_stop_before(self):
+    def on_stop_before(self) -> None:
         """
         Called when the app stops before the thread is stopped. Should be used to stop any blocking
         calls in the thread loop.
@@ -145,7 +145,7 @@ class Service:
 
         pass
 
-    def on_stop(self):
+    def on_stop(self) -> None:
         """
         Called when the app stops after the thread has stopped. Should be used to stop any hardware
         the service controls.
@@ -155,7 +155,7 @@ class Service:
 
         pass
 
-    def sleep(self, timeout: float):
+    def sleep(self, timeout: float) -> None:
         """
         Sleep for X seconds, that can be interupted if `stop()` is called.
 
@@ -167,7 +167,7 @@ class Service:
 
         self._event.wait(timeout)
 
-    def sleep_ms(self, timeout: float):
+    def sleep_ms(self, timeout: float) -> None:
         """
         Sleep for X milliseconds, that can be interupted if `stop()` is called.
 
@@ -179,7 +179,7 @@ class Service:
 
         self._event.wait(timeout / 1000)
 
-    def cancel(self):
+    def cancel(self) -> None:
         """Cancel the service. Can be used to stop the service from `self.on_loop()`."""
 
         self._event.set()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,6 +74,21 @@ ignore = [
     # FIXME: These should be turned back on but take effort
     "D102",  # Missing docstring in public method
     "D107",  # Missing docstring in `__init__`
+    "PLR0915", # Too many statements
+    "S202",  # Uses of `tarfile.extractall()`
+    "S108",  # Insecure usage of temporary directory
+    "S602",  # `subprocess` call with `shell=True
+    "S607",  # Starting a process with a partial executable path
+    "RUF012",# Mutable default value for class attribute
+    "PLR0912",# Too many branches
+    "ARG002", # Unused method argument
+    "C901", # Function is too complex
+    "FBT001",
+    "FBT002",
+    "PTH",
+    "PERF203",
+    "BLE001",
+    "D",
     # These are the opposite of what I want
     "D413",  # Missing blank line after last section
     "EM101", # Exception must not use a string literal
@@ -86,6 +101,7 @@ ignore = [
     # the numbers it flags are obvious from context.
     "PLR2004",  # Magic value used in comparison
     "TID252",  # Prefer absolute imports over relative imports from parent modules
+    "ERA001",  # Remove commented out code. Nice but too many false positives
 ]
 
 [tool.ruff.lint.per-file-ignores]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -90,7 +90,7 @@ ignore = [
 
 [tool.ruff.lint.per-file-ignores]
 # Test specific lint ignores. These files are not part of the main
-# pass-commander application
+# olaf application
 "tests/**/{test_*,__init__,conftest}.py" = [
     "S101",  # assert - pytest prefers plain assert
     "S311",

--- a/tests/internals/__init__.py
+++ b/tests/internals/__init__.py
@@ -28,7 +28,7 @@ class MockNode(Node):
 
         self._setup_node()
 
-    def send_tpdo(self, tpdo: int, raise_error: bool = True) -> None:  # noqa: FBT001,FBT002
+    def send_tpdo(self, tpdo: int, raise_error: bool = True) -> None:
         pass  # override to do nothing
 
 
@@ -63,7 +63,7 @@ class MockApp:
         self,
         index: int | str,
         subindex: None | int | str,
-        value: bool | str | bytes,  # noqa: FBT001
+        value: bool | str | bytes,
     ) -> None:
         co_node = self.node._node
         domain = canopen.objectdictionary.DOMAIN


### PR DESCRIPTION
This tries to add a complete set of type hints and cleans up some of the easy lints. It doesn't successfully type check yet because dealing with canopen-python is difficult but hopefully other projects that use olaf will have a better time of their own type checking. Because of that I've not enabled the mypy CI pass yet. This does however enable the ruff CI pass and fixes a bunch of the easy lints. The harder ones I've deferred to a later time but we should really get around to them.

It's a lot of line changes but most are rather trivial and generally don't change any behavior. See the commit messages for the limited cases where it does.