### PR TITLE
Transfer update files over can

### DIFF
--- a/olaf/_internals/services/updater.py
+++ b/olaf/_internals/services/updater.py
@@ -7,8 +7,8 @@ from loguru import logger
 
 from time import monotonic
 
-from ...common.oresat_file import OreSatFile
 from ...common.service import Service
+from ...common.oresat_file import OreSatFile
 from ..updater import Updater, UpdaterError
 from ...canopen.master_node import MasterNode
 
@@ -67,7 +67,7 @@ class UpdaterService(Service):
 
     def send_update(self, i: OreSatFile) -> None:
         try:
-            self.node.od_db[i.card_underscore].node_id
+            remote_node_id = self.node.od_db[i.card_underscore].node_id
         except KeyError:
             logger.error(
                 f"Could not find node for update {i.card_underscore} in object dictionary db"
@@ -91,6 +91,7 @@ class UpdaterService(Service):
             data = f.read()
 
         # transfer the file
+        logger.info(f"Sending {i.name} to remote node {remote_node_id}")
         self.node.sdo_write(i.card_underscore, "fwrite_cache", "file_name", i.name)
         self.node.sdo_write(i.card_underscore, "fwrite_cache", "file_data", data)
 

--- a/olaf/_internals/services/updater.py
+++ b/olaf/_internals/services/updater.py
@@ -11,6 +11,8 @@ from ...common.service import Service
 from ..updater import Updater, UpdaterError
 from ...canopen.master_node import MasterNode
 
+from ...common.OreSatFile import OreSatFile
+
 class UpdaterService(Service):
     """Service for interacting with the updater"""
     INACTIVE_TIMEOUT = 5

--- a/olaf/_internals/services/updater.py
+++ b/olaf/_internals/services/updater.py
@@ -4,6 +4,7 @@ import os
 from os.path import abspath
 from time import monotonic
 
+from canopen import SdoCommunicationError
 from loguru import logger
 
 from ...canopen.master_node import MasterNode
@@ -15,13 +16,14 @@ from ..updater import Updater, UpdaterError
 class UpdaterService(Service):
     """Service for interacting with the updater"""
 
+    INACTIVE_TIMEOUT = 5
+
     def __init__(self, updater: Updater) -> None:
         super().__init__()
         self._updater = updater
         self._hostname = os.uname()[1].removeprefix("oresat-")
 
     def on_start(self) -> None:
-
         # make sure defaults are set correctly
         self.node.od_write("updater", "update", value=False)
         self.node.od_write("updater", "make_status_file", value=False)
@@ -32,10 +34,9 @@ class UpdaterService(Service):
         self.node.add_sdo_callbacks("updater", "check_for_updates", None, self.check_for_updates)
 
         # check for update files in fwrite cache
-        self.check_for_updates()
+        self._check_local_updates()
 
     def on_loop(self) -> None:
-
         # check for flag to start a update
         if self.node.od_read("updater", "update"):
             try:
@@ -73,14 +74,20 @@ class UpdaterService(Service):
             )
             return
 
-        if self.node.od_db[i.card_underscore][0x3002][0x4].name != "sw_version":
+        # Check if the target card is a software or firmware card. This update path only works
+        # with software cards and the easiest way to tell from the object dictionary is to check
+        # od["versions"][4] which will either be named "fw_version" or "sw_version"
+        if self.node.od_db[i.card_underscore]['versions'][0x4].name != "sw_version":
             logger.warning(f"Update archive is for {i.card_underscore}, which is not OLAF.")
             return
 
-        if (
-            self.node.node_status[i.card_underscore][0] != 0x05
-            or self.node.node_status[i.card_underscore][2] + self.INACTIVE_TIMEOUT < monotonic()
-        ):
+        if i.card_underscore not in self.node.node_status:
+            logger.warning(f"'{i.card_underscore}' not found in node_status, skipping")
+            return
+
+        heartbeat = self.node.node_status[i.card_underscore]
+        # State 0x05 is "Operational" - see CANopen hearbeat spec
+        if heartbeat.state != 0x05 or heartbeat.timestamp + self.INACTIVE_TIMEOUT < monotonic():
             logger.warning(f"Update archive is for {i.card_underscore}, which is not on.")
             return
 
@@ -90,20 +97,36 @@ class UpdaterService(Service):
             data = f.read()
 
         # transfer the file
-        logger.info(f"Sending {i.name} to remote node {remote_node_id}")
-        self.node.sdo_write(i.card_underscore, "fwrite_cache", "file_name", i.name)
-        self.node.sdo_write(i.card_underscore, "fwrite_cache", "file_data", data)
+        logger.info(f"Sending {i.name} to remote node {remote_node_id:#02x}")
+        try:
+            self.node.sdo_write(i.card_underscore, "fwrite_cache", "file_name", i.name)
+            self.node.sdo_write(i.card_underscore, "fwrite_cache", "file_data", data)
+        except SdoCommunicationError as e:
+            logger.error(f"Failed writing {i.name} to {remote_node_id:#02x}: {e}")
+            return
 
         # delete the update file
         self.node.fwrite_cache.remove(i.name)
 
+    def _check_local_updates(self) -> None:
+        """Check for updates in the fwrite cache."""
+        logger.info("Checking for local updates")
+        for file in self.node.fwrite_cache.files("update"):
+            if file.card == self._hostname:
+                self._updater.add_update_archive(self.node.fwrite_cache.dir + "/" + file.name)
+                self.node.fwrite_cache.remove(file.name)
+                logger.info(f"updater moved {file.name} into update cache")
+
+    def _check_remote_updates(self) -> None:
+        """Check the fwrite cache for files that should be distributed to other cards"""
+        logger.info("Checking for remote updates")
+        if isinstance(self.node, MasterNode):
+            for file in self.node.fwrite_cache.files("update"):
+                if file.card != self._hostname:
+                    logger.info(f"Sending {file.name} to {file.card_underscore}")
+                    self.send_update(file)
+
     def check_for_updates(self, value: bool = True) -> None:
         """Check for updates in the fwrite cache. Send updates to other cards if they are on"""
-        for i in self.node.fwrite_cache.files("update"):
-            if i.card == self._hostname:
-                self._updater.add_update_archive(self.node.fwrite_cache.dir + "/" + i.name)
-                self.node.fwrite_cache.remove(i.name)
-                logger.info(f"updater moved {i.name} into update cache")
-
-            elif isinstance(self.node, MasterNode):
-                self.send_update(i)
+        self._check_remote_updates()
+        self._check_local_updates()

--- a/olaf/_internals/services/updater.py
+++ b/olaf/_internals/services/updater.py
@@ -11,7 +11,7 @@ from ...common.service import Service
 from ..updater import Updater, UpdaterError
 from ...canopen.master_node import MasterNode
 
-from ...common.OreSatFile import OreSatFile
+from ...common.oresat_file import OreSatFile
 
 class UpdaterService(Service):
     """Service for interacting with the updater"""

--- a/olaf/_internals/services/updater.py
+++ b/olaf/_internals/services/updater.py
@@ -6,7 +6,7 @@ from loguru import logger
 
 from ...common.service import Service
 from ..updater import Updater, UpdaterError
-
+from ...canopen.master_node import MasterNode
 
 class UpdaterService(Service):
     """Service for interacting with the updater"""
@@ -28,11 +28,7 @@ class UpdaterService(Service):
         self.node.add_sdo_callbacks("updater", "cache_length", self.on_read_cache_len, None)
 
         # check for update files in fwrite cache
-        for i in self.node.fwrite_cache.files("update"):
-            if i.card == self._hostname:
-                self._updater.add_update_archive(self.node.fwrite_cache.dir + "/" + i.name)
-                self.node.fwrite_cache.remove(i.name)
-                logger.info(f"updater moved {i.name} into update cache")
+        self.check_for_updates()
 
     def on_loop(self):
 
@@ -63,3 +59,19 @@ class UpdaterService(Service):
     def on_read_cache_json(self) -> str:
         """SDO read callback to get list of updates cached as str"""
         return " ".join([i.name for i in self._updater.updates_cached])
+
+    def check_for_updates(self) -> None:
+        """Check for updates in the fwrite cache. Transfer updates for remote cards if any are present"""
+        for i in self.node.fwrite_cache.files("update"):
+            if i.card == self._hostname:
+                self._updater.add_update_archive(self.node.fwrite_cache.dir + "/" + i.name)
+                self.node.fwrite_cache.remove(i.name)
+                logger.info(f"updater moved {i.name} into update cache")
+            elif isinstance(self.node, MasterNode):  # Find out if the update is for a valid card.
+                try:
+                    remote_node_id = self.node.od_db[i.card_underscore].node_id
+                except KeyError:
+                    logger.error(f"Could not find update archive's remote node {i.card_underscore}, in object dictionary database")
+                    continue # we may want to try to rename the file here so that this warning doesn't keep occuring.
+                # transfer the file
+                logger.error(f"Found the node id for card {i.card_underscore}: {remote_node_id}")

--- a/olaf/_internals/services/updater.py
+++ b/olaf/_internals/services/updater.py
@@ -2,15 +2,14 @@
 
 import os
 from os.path import abspath
+from time import monotonic
 
 from loguru import logger
 
-from time import monotonic
-
-from ...common.service import Service
-from ...common.oresat_file import OreSatFile
-from ..updater import Updater, UpdaterError
 from ...canopen.master_node import MasterNode
+from ...common.oresat_file import OreSatFile
+from ...common.service import Service
+from ..updater import Updater, UpdaterError
 
 
 class UpdaterService(Service):

--- a/olaf/_internals/services/updater.py
+++ b/olaf/_internals/services/updater.py
@@ -7,11 +7,10 @@ from loguru import logger
 
 from time import monotonic
 
+from ...common.oresat_file import OreSatFile
 from ...common.service import Service
 from ..updater import Updater, UpdaterError
 from ...canopen.master_node import MasterNode
-
-from ...common.oresat_file import OreSatFile
 
 
 class UpdaterService(Service):
@@ -68,18 +67,18 @@ class UpdaterService(Service):
 
     def send_update(self, i: OreSatFile) -> None:
         try:
-            remote_node_id = self.node.od_db[i.card_underscore].node_id
+            self.node.od_db[i.card_underscore].node_id
         except KeyError:
             logger.error(
-                f"Could not find update archive's remote node {i.card_underscore} in object dictionary database"
+                f"Could not find node for update {i.card_underscore} in object dictionary db"
             )
-            return  # we may want to try to rename the file here so that this warning doesn't keep occuring.
+            return
 
         if self.node.od_db[i.card_underscore][0x3002][0x4].name != "sw_version":
             logger.warning(f"Update archive is for {i.card_underscore}, which is not OLAF.")
             return
 
-        if (  # Has a heartbeat saying that it is alive, and less than INACTIVE_TIMEOUT since last heartbeat.
+        if (
             self.node.node_status[i.card_underscore][0] != 0x05
             or self.node.node_status[i.card_underscore][2] + self.INACTIVE_TIMEOUT < monotonic()
         ):
@@ -99,7 +98,7 @@ class UpdaterService(Service):
         self.node.fwrite_cache.remove(i.name)
 
     def check_for_updates(self, value: bool = True) -> None:
-        """Check for updates in the fwrite cache. Transfer updates for remote cards if any are present"""
+        """Check for updates in the fwrite cache. Send updates to other cards if they are on"""
         for i in self.node.fwrite_cache.files("update"):
             if i.card == self._hostname:
                 self._updater.add_update_archive(self.node.fwrite_cache.dir + "/" + i.name)

--- a/olaf/_internals/services/updater.py
+++ b/olaf/_internals/services/updater.py
@@ -10,6 +10,7 @@ from ...canopen.master_node import MasterNode
 
 class UpdaterService(Service):
     """Service for interacting with the updater"""
+    INACTIVE_TIMEOUT = 5
 
     def __init__(self, updater: Updater):
         super().__init__()
@@ -67,11 +68,27 @@ class UpdaterService(Service):
                 self._updater.add_update_archive(self.node.fwrite_cache.dir + "/" + i.name)
                 self.node.fwrite_cache.remove(i.name)
                 logger.info(f"updater moved {i.name} into update cache")
-            elif isinstance(self.node, MasterNode):  # Find out if the update is for a valid card.
+            elif isinstance(self.node, MasterNode):
                 try:
                     remote_node_id = self.node.od_db[i.card_underscore].node_id
                 except KeyError:
                     logger.error(f"Could not find update archive's remote node {i.card_underscore}, in object dictionary database")
                     continue # we may want to try to rename the file here so that this warning doesn't keep occuring.
+
+                if self.node.od_db[i.card_underscore][0x3002][0x4].name != "sw_version":
+                    logger.warning(f"Update archive is for {i.card_underscore}, which is not OLAF.")
+                    continue
+
+                if (  # Has a heartbeat saying that it is alive, and less than INACTIVE_TIMEOUT since last heartbeat.
+                    self.node.node_status[i.card_underscore][0] != b"0x05" or
+                    self.node.node_status[i.card_underscore][2] + INACTIVE_TIMEOUT < monotonic()
+                ):
+                    logger.warning(f"Update archive is for {i.card_underscore}, which is not on.")
+                    continue
+
+                # get the file data
+                
+
                 # transfer the file
-                logger.error(f"Found the node id for card {i.card_underscore}: {remote_node_id}")
+                node.sdo_write(i.card_underscore, "fwrite_cache", "file_data", i.name)
+                node.sdo_write(i.card_underscore, "fwrite_cache", "file_data", VSAINSFbon)

--- a/olaf/_internals/services/updater.py
+++ b/olaf/_internals/services/updater.py
@@ -1,8 +1,11 @@
 """Service for interacting with the updater"""
 
 import os
+from os.path import abspath
 
 from loguru import logger
+
+from time import monotonic
 
 from ...common.service import Service
 from ..updater import Updater, UpdaterError
@@ -27,6 +30,7 @@ class UpdaterService(Service):
         self.node.add_sdo_callbacks("updater", "status", self.on_read_status, None)
         self.node.add_sdo_callbacks("updater", "cache_files_json", self.on_read_cache_json, None)
         self.node.add_sdo_callbacks("updater", "cache_length", self.on_read_cache_len, None)
+        self.node.add_sdo_callbacks("updater", "check_for_updates", None, self.check_for_updates)
 
         # check for update files in fwrite cache
         self.check_for_updates()
@@ -66,18 +70,18 @@ class UpdaterService(Service):
             remote_node_id = self.node.od_db[i.card_underscore].node_id
         except KeyError:
             logger.error(f"Could not find update archive's remote node {i.card_underscore}, in object dictionary database")
-            continue  # we may want to try to rename the file here so that this warning doesn't keep occuring.
+            return  # we may want to try to rename the file here so that this warning doesn't keep occuring.
 
         if self.node.od_db[i.card_underscore][0x3002][0x4].name != "sw_version":
             logger.warning(f"Update archive is for {i.card_underscore}, which is not OLAF.")
-            continue
+            return
 
         if (  # Has a heartbeat saying that it is alive, and less than INACTIVE_TIMEOUT since last heartbeat.
-            self.node.node_status[i.card_underscore][0] != b"0x05" or
-            self.node.node_status[i.card_underscore][2] + INACTIVE_TIMEOUT < monotonic()
+            self.node.node_status[i.card_underscore][0] != 0x05 or
+            self.node.node_status[i.card_underscore][2] + self.INACTIVE_TIMEOUT < monotonic()
         ):
             logger.warning(f"Update archive is for {i.card_underscore}, which is not on.")
-            continue
+            return
 
         # get the file data
         path = abspath(self.node.fwrite_cache.dir + "/" + i.name)
@@ -85,13 +89,13 @@ class UpdaterService(Service):
             data = f.read()
 
         # transfer the file
-        self.node.sdo_write(i.card_underscore, "fwrite_cache", "file_data", i.name)
+        self.node.sdo_write(i.card_underscore, "fwrite_cache", "file_name", i.name)
         self.node.sdo_write(i.card_underscore, "fwrite_cache", "file_data", data)
 
         # delete the update file
         self.node.fwrite_cache.remove(i.name)
 
-    def check_for_updates(self) -> None:
+    def check_for_updates(self, value: bool = True) -> None:
         """Check for updates in the fwrite cache. Transfer updates for remote cards if any are present"""
         for i in self.node.fwrite_cache.files("update"):
             if i.card == self._hostname:

--- a/olaf/_internals/services/updater.py
+++ b/olaf/_internals/services/updater.py
@@ -61,6 +61,36 @@ class UpdaterService(Service):
         """SDO read callback to get list of updates cached as str"""
         return " ".join([i.name for i in self._updater.updates_cached])
 
+    def send_update(self, i: OreSatFile) -> None:
+        try:
+            remote_node_id = self.node.od_db[i.card_underscore].node_id
+        except KeyError:
+            logger.error(f"Could not find update archive's remote node {i.card_underscore}, in object dictionary database")
+            continue  # we may want to try to rename the file here so that this warning doesn't keep occuring.
+
+        if self.node.od_db[i.card_underscore][0x3002][0x4].name != "sw_version":
+            logger.warning(f"Update archive is for {i.card_underscore}, which is not OLAF.")
+            continue
+
+        if (  # Has a heartbeat saying that it is alive, and less than INACTIVE_TIMEOUT since last heartbeat.
+            self.node.node_status[i.card_underscore][0] != b"0x05" or
+            self.node.node_status[i.card_underscore][2] + INACTIVE_TIMEOUT < monotonic()
+        ):
+            logger.warning(f"Update archive is for {i.card_underscore}, which is not on.")
+            continue
+
+        # get the file data
+        path = abspath(self.node.fwrite_cache.dir + "/" + i.name)
+        with open(path, "rb") as f:
+            data = f.read()
+
+        # transfer the file
+        self.node.sdo_write(i.card_underscore, "fwrite_cache", "file_data", i.name)
+        self.node.sdo_write(i.card_underscore, "fwrite_cache", "file_data", data)
+
+        # delete the update file
+        self.node.fwrite_cache.remove(i.name)
+
     def check_for_updates(self) -> None:
         """Check for updates in the fwrite cache. Transfer updates for remote cards if any are present"""
         for i in self.node.fwrite_cache.files("update"):
@@ -68,27 +98,6 @@ class UpdaterService(Service):
                 self._updater.add_update_archive(self.node.fwrite_cache.dir + "/" + i.name)
                 self.node.fwrite_cache.remove(i.name)
                 logger.info(f"updater moved {i.name} into update cache")
+
             elif isinstance(self.node, MasterNode):
-                try:
-                    remote_node_id = self.node.od_db[i.card_underscore].node_id
-                except KeyError:
-                    logger.error(f"Could not find update archive's remote node {i.card_underscore}, in object dictionary database")
-                    continue # we may want to try to rename the file here so that this warning doesn't keep occuring.
-
-                if self.node.od_db[i.card_underscore][0x3002][0x4].name != "sw_version":
-                    logger.warning(f"Update archive is for {i.card_underscore}, which is not OLAF.")
-                    continue
-
-                if (  # Has a heartbeat saying that it is alive, and less than INACTIVE_TIMEOUT since last heartbeat.
-                    self.node.node_status[i.card_underscore][0] != b"0x05" or
-                    self.node.node_status[i.card_underscore][2] + INACTIVE_TIMEOUT < monotonic()
-                ):
-                    logger.warning(f"Update archive is for {i.card_underscore}, which is not on.")
-                    continue
-
-                # get the file data
-                
-
-                # transfer the file
-                node.sdo_write(i.card_underscore, "fwrite_cache", "file_data", i.name)
-                node.sdo_write(i.card_underscore, "fwrite_cache", "file_data", VSAINSFbon)
+                self.send_update(i)

--- a/olaf/_internals/services/updater.py
+++ b/olaf/_internals/services/updater.py
@@ -13,8 +13,10 @@ from ...canopen.master_node import MasterNode
 
 from ...common.oresat_file import OreSatFile
 
+
 class UpdaterService(Service):
     """Service for interacting with the updater"""
+
     INACTIVE_TIMEOUT = 5
 
     def __init__(self, updater: Updater):
@@ -71,7 +73,9 @@ class UpdaterService(Service):
         try:
             remote_node_id = self.node.od_db[i.card_underscore].node_id
         except KeyError:
-            logger.error(f"Could not find update archive's remote node {i.card_underscore}, in object dictionary database")
+            logger.error(
+                f"Could not find update archive's remote node {i.card_underscore} in object dictionary database"
+            )
             return  # we may want to try to rename the file here so that this warning doesn't keep occuring.
 
         if self.node.od_db[i.card_underscore][0x3002][0x4].name != "sw_version":
@@ -79,8 +83,8 @@ class UpdaterService(Service):
             return
 
         if (  # Has a heartbeat saying that it is alive, and less than INACTIVE_TIMEOUT since last heartbeat.
-            self.node.node_status[i.card_underscore][0] != 0x05 or
-            self.node.node_status[i.card_underscore][2] + self.INACTIVE_TIMEOUT < monotonic()
+            self.node.node_status[i.card_underscore][0] != 0x05
+            or self.node.node_status[i.card_underscore][2] + self.INACTIVE_TIMEOUT < monotonic()
         ):
             logger.warning(f"Update archive is for {i.card_underscore}, which is not on.")
             return

--- a/olaf/_internals/updater.py
+++ b/olaf/_internals/updater.py
@@ -24,7 +24,7 @@ INSTRUCTIONS = {
     "DPKG_INSTALL": "dpkg -i",
     "DPKG_REMOVE": "dpkg -r",
     "DPKG_PURGE": "dpkg -P",
-    "PIP_INSTALL": "python3 -m pip install",
+    "PIP_INSTALL": "python3 -m pip install --break-system-packages",
     "PIP_UNINSTALL": "python3 -m pip uninstall",
 }
 """All the valid instruction. Values are the commands."""

--- a/olaf/common/oresat_file.py
+++ b/olaf/common/oresat_file.py
@@ -104,6 +104,12 @@ class OreSatFile:
         """str: The card the file is for or the card the file was made on. Read only."""
 
         return self._card
+    
+    @property
+    def card_underscore(self) -> str:
+        """str: The card the file is for, but in the format expected by OreSatConfigs. Read only."""
+
+        return self.card.replace("-","_")
 
     @property
     def keyword(self) -> str:

--- a/olaf/common/oresat_file.py
+++ b/olaf/common/oresat_file.py
@@ -104,12 +104,12 @@ class OreSatFile:
         """str: The card the file is for or the card the file was made on. Read only."""
 
         return self._card
-    
+
     @property
     def card_underscore(self) -> str:
         """str: The card the file is for, but in the format expected by OreSatConfigs. Read only."""
 
-        return self.card.replace("-","_")
+        return self.card.replace("-", "_")
 
     @property
     def keyword(self) -> str:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ dependencies = [
     "loguru",
     "psutil",
     "python-can>=4.3.0",
-    "oresat-configs>=0.8.0,<1.0.0",
+    "oresat-configs>=1.1.1",
 ]
 
 dynamic = ["version"]


### PR DESCRIPTION
Fixes #36 . 
Updates for octavo cards are now sent over the can bus when the target node is active and the updater service checks for new files. This will never happen automatically, so this should be triggered by powering on the target node via EDL and setting "updater""check_for_updates" to some value afterwards.

While this process should be improved in the future, it should be serviceable for the immediate future.

Also fixes an issue with pip on images running newer versions of python.