### PR TITLE
Use PyPI trusted publishing

### DIFF
--- a/.github/workflows/pypi.yaml
+++ b/.github/workflows/pypi.yaml
@@ -2,20 +2,20 @@ name: Upload Python Package
 
 on:
   release:
-    types: [published]
+    types: [ "published" ]
 
 jobs:
   deploy:
-
     runs-on: ubuntu-latest
+    environment: pypi
+    permissions:
+      id-token: write
 
     steps:
-    - uses: actions/checkout@v3
-
-    - name: Set up Python
-      uses: actions/setup-python@v3
+    - uses: actions/checkout@v6
+    - uses: actions/setup-python@v6
       with:
-        python-version: '3.x'
+        python-version: "3.9"
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
@@ -24,9 +24,5 @@ jobs:
     - name: Build package
       run: python -m build
 
-    - name: Publish package
-      uses: pypa/gh-action-pypi-publish@27b31702a0e7fc50959f5ad993c78deac1bdfc29
-      with:
-        user: __token__
-        password: ${{ secrets.PYPI_API_TOKEN }}
-
+    - name: Publish
+      uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
This is apparently the new more secure way of sending packages to PyPI.