### PR TITLE
Save board number from EEPROM to OD

### DIFF
--- a/olaf/__init__.py
+++ b/olaf/__init__.py
@@ -174,7 +174,8 @@ def olaf_setup(name: str, args: Namespace | None = None) -> tuple[Namespace, Ore
         try:
             eeprom = Eeprom()
             version = f"{eeprom.major}.{eeprom.minor}"
-            logger.info(f"detected v{version} card")
+            logger.info(f"detected v{version} card number {eeprom.board}")
+            od["versions"]["board_number"] = eeprom.board
         except (PermissionError, FileNotFoundError, OSError, UnicodeDecodeError):
             logger.warning("could not read hardware info from eeprom")
     if args.hardware_version != "0.0":

--- a/olaf/board/eeprom.py
+++ b/olaf/board/eeprom.py
@@ -59,6 +59,7 @@ class Eeprom:
         self.is_oresat_card = False
         self.major = 0
         self.minor = 0
+        self.board = 0
 
         if self.serial_id != "PSAS":
             if self.nice_name == "pocketbeagle":
@@ -73,3 +74,4 @@ class Eeprom:
                 self.device_tree = f"{self.nice_name}-{self.version}.dtb"
             self.major = int(data[12:14])
             self.minor = int(data[14:16])
+            self.board = int(self.id)


### PR DESCRIPTION
Now that the oresat boards EEPROM record the board number and oresat-configs has a spot to save it in, this wires it all up to be reported.