### PR TITLE
Fix crash when reconnecting to bus on master node

### DIFF
--- a/olaf/canopen/master_node.py
+++ b/olaf/canopen/master_node.py
@@ -73,6 +73,7 @@ class MasterNode(Node):
             self.node_status[key] = NodeHeartbeatInfo(0xFF, 0.0, 0.0)
 
         for remote_node in self._remote_nodes.values():
+            remote_node.remove_network()
             self._network.add_node(remote_node)
 
     def _on_heartbeat(self, cob_id: int, data: bytes, timestamp: float) -> None:


### PR DESCRIPTION
The remote nodes need their network removed before re-adding. This should probably be done somewhere that gets notified of when the bus goes down but I can't figure out an easy way of doing that right now.